### PR TITLE
🐛(circleci) skip check circleci configuration on master and tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,68 +326,11 @@ workflows:
         name: no-change-cnfpt
   demo:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /demo-.*/
-        name: check-changelog-demo
-        site: demo
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /demo-.*/
-        name: lint-changelog--demo
-        site: demo
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /demo-.*/
-        name: build-front-production-demo
-        site: demo
-    - lint-front:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: lint-front-demo
-        requires:
-        - build-front-production-demo
-        site: demo
-    - build-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: build-back-demo
-        site: demo
-    - lint-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: lint-back-demo
-        requires:
-        - build-back-demo
-        site: demo
-    - test-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: test-back-demo
-        requires:
-        - build-back-demo
-        site: demo
-    - hub:
-        filters:
-          tags:
-            only: /^demo-.*/
-        image_name: richie-demo
-        name: hub-demo
-        requires:
-        - lint-front-demo
-        - lint-back-demo
-        site: demo
+            only: /.*/
+        name: no-change-demo
   funcorporate:
     jobs:
     - no-change:
@@ -410,8 +353,8 @@ workflows:
             only: /.*/
     - check-configuration:
         filters:
-          tags:
-            only: /.*/
+          branches:
+            ignore: master
     - lint-bash:
         filters:
           tags:

--- a/.circleci/src/workflows/site-factory.yml
+++ b/.circleci/src/workflows/site-factory.yml
@@ -9,8 +9,8 @@ jobs:
   # Check that circleci configuration is updated
   - check-configuration:
       filters:
-        tags:
-          only: /.*/
+        branches:
+          ignore: master
   # Lint bash scripts in /bin
   - lint-bash:
       filters:


### PR DESCRIPTION
## Purpose

Builds are all failing on the master branch.

## Proposal

The circleci configuration on master and tags (that are applied to the master branch) will always be different from what is being generated by an update command... because by definition changes are
computed as compared to the master branch.

Skip checking the circleci configuration on the master branch and on tags.
