### PR TITLE
🐛(circleci) remove check changelog job for tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,260 +316,32 @@ version: 2.1
 workflows:
   cnfpt:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /cnfpt-.*/
-        name: check-changelog-cnfpt
-        site: cnfpt
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /cnfpt-.*/
-        name: lint-changelog--cnfpt
-        site: cnfpt
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /cnfpt-.*/
-        name: build-front-production-cnfpt
-        site: cnfpt
-    - lint-front:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: lint-front-cnfpt
-        requires:
-        - build-front-production-cnfpt
-        site: cnfpt
-    - build-back:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: build-back-cnfpt
-        site: cnfpt
-    - lint-back:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: lint-back-cnfpt
-        requires:
-        - build-back-cnfpt
-        site: cnfpt
-    - test-back:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: test-back-cnfpt
-        requires:
-        - build-back-cnfpt
-        site: cnfpt
-    - hub:
-        filters:
-          tags:
-            only: /^cnfpt-.*/
-        image_name: cnfpt
-        name: hub-cnfpt
-        requires:
-        - lint-front-cnfpt
-        - lint-back-cnfpt
-        site: cnfpt
+            only: /.*/
+        name: no-change-cnfpt
   demo:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /demo-.*/
-        name: check-changelog-demo
-        site: demo
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /demo-.*/
-        name: lint-changelog--demo
-        site: demo
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /demo-.*/
-        name: build-front-production-demo
-        site: demo
-    - lint-front:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: lint-front-demo
-        requires:
-        - build-front-production-demo
-        site: demo
-    - build-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: build-back-demo
-        site: demo
-    - lint-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: lint-back-demo
-        requires:
-        - build-back-demo
-        site: demo
-    - test-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: test-back-demo
-        requires:
-        - build-back-demo
-        site: demo
-    - hub:
-        filters:
-          tags:
-            only: /^demo-.*/
-        image_name: richie-demo
-        name: hub-demo
-        requires:
-        - lint-front-demo
-        - lint-back-demo
-        site: demo
+            only: /.*/
+        name: no-change-demo
   funcorporate:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /funcorporate-.*/
-        name: check-changelog-funcorporate
-        site: funcorporate
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /funcorporate-.*/
-        name: lint-changelog--funcorporate
-        site: funcorporate
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /funcorporate-.*/
-        name: build-front-production-funcorporate
-        site: funcorporate
-    - lint-front:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: lint-front-funcorporate
-        requires:
-        - build-front-production-funcorporate
-        site: funcorporate
-    - build-back:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: build-back-funcorporate
-        site: funcorporate
-    - lint-back:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: lint-back-funcorporate
-        requires:
-        - build-back-funcorporate
-        site: funcorporate
-    - test-back:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: test-back-funcorporate
-        requires:
-        - build-back-funcorporate
-        site: funcorporate
-    - hub:
-        filters:
-          tags:
-            only: /^funcorporate-.*/
-        image_name: funcorporate
-        name: hub-funcorporate
-        requires:
-        - lint-front-funcorporate
-        - lint-back-funcorporate
-        site: funcorporate
+            only: /.*/
+        name: no-change-funcorporate
   funmooc:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /funmooc-.*/
-        name: check-changelog-funmooc
-        site: funmooc
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /funmooc-.*/
-        name: lint-changelog--funmooc
-        site: funmooc
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /funmooc-.*/
-        name: build-front-production-funmooc
-        site: funmooc
-    - lint-front:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: lint-front-funmooc
-        requires:
-        - build-front-production-funmooc
-        site: funmooc
-    - build-back:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: build-back-funmooc
-        site: funmooc
-    - lint-back:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: lint-back-funmooc
-        requires:
-        - build-back-funmooc
-        site: funmooc
-    - test-back:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: test-back-funmooc
-        requires:
-        - build-back-funmooc
-        site: funmooc
-    - hub:
-        filters:
-          tags:
-            only: /^funmooc-.*/
-        image_name: funmooc
-        name: hub-funmooc
-        requires:
-        - lint-front-funmooc
-        - lint-back-funmooc
-        site: funmooc
+            only: /.*/
+        name: no-change-funmooc
   site-factory:
     jobs:
     - lint-git:

--- a/.circleci/src/workflows/site_jobs.yml.tpl
+++ b/.circleci/src/workflows/site_jobs.yml.tpl
@@ -8,8 +8,6 @@ ${SITE}:
         filters:
           branches:
             ignore: master
-          tags:
-            only: /${SITE}-.*/
     - lint-changelog:
         name: lint-changelog--${SITE}
         site: ${SITE}


### PR DESCRIPTION
## Purpose

The job that checks if the CHANGELOG file is modified  is for pull requests. When we tag the master branch, the CHANGELOG file will never be modified.

## Proposal

Stop running the `check-changelog` job on builds triggered by a tag.
