### PR TITLE
🐛(demo) add missing factory-boy dependency to demo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,11 +323,66 @@ workflows:
         name: no-change-cnfpt
   demo:
     jobs:
-    - no-change:
+    - check-changelog:
+        filters:
+          branches:
+            ignore: master
+        name: check-changelog-demo
+        site: demo
+    - lint-changelog:
+        filters:
+          branches:
+            ignore: master
+          tags:
+            only: /demo-.*/
+        name: lint-changelog--demo
+        site: demo
+    - build-front-production:
         filters:
           tags:
-            only: /.*/
-        name: no-change-demo
+            only: /demo-.*/
+        name: build-front-production-demo
+        site: demo
+    - lint-front:
+        filters:
+          tags:
+            only: /demo-.*/
+        name: lint-front-demo
+        requires:
+        - build-front-production-demo
+        site: demo
+    - build-back:
+        filters:
+          tags:
+            only: /demo-.*/
+        name: build-back-demo
+        site: demo
+    - lint-back:
+        filters:
+          tags:
+            only: /demo-.*/
+        name: lint-back-demo
+        requires:
+        - build-back-demo
+        site: demo
+    - test-back:
+        filters:
+          tags:
+            only: /demo-.*/
+        name: test-back-demo
+        requires:
+        - build-back-demo
+        site: demo
+    - hub:
+        filters:
+          tags:
+            only: /^demo-.*/
+        image_name: richie-demo
+        name: hub-demo
+        requires:
+        - lint-front-demo
+        - lint-back-demo
+        site: demo
   funcorporate:
     jobs:
     - no-change:

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing factory-boy dependency to allow generating the demo site
+
 ## [2.0.0-beta.7] - 2020-06-08
 
 First demo image for richie to 2.0.0-beta.7

--- a/sites/demo/requirements/base.txt
+++ b/sites/demo/requirements/base.txt
@@ -1,10 +1,9 @@
 boto3==1.9.96
 Django<3
 django-configurations==2.2
-# Superior versions of django-storages are not compatible with
-# ManifestStaticFilesStorage
 django-storages==1.9.1
 dockerflow==2019.10.0
+factory-boy==2.12.0
 gunicorn==20.0.4
 psycopg2-binary==2.8.5
 richie==2.0.0-beta.7


### PR DESCRIPTION
### Purpose

We normally don't include factory-boy in production images but richie demo is a special image that needs to generate the demo site.

### Proposal

I added factory-boy in the base.txt requirements file.