### PR TITLE
🐛(Makefile) fix resetting data folder when absent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build: ## build all containers
 
 reset:  ## Remove database and local files
 	$(COMPOSE) stop
-	rm -Ir data/*
+	rm -Ir data/* || exit 0
 	$(COMPOSE) rm db
 .PHONY: reset
 


### PR DESCRIPTION
## Purpose 

When bootstrapping the project for the first time, the data directory is absent and the reset rule should not fail.

## Proposal

Add `|| exit 0` after the reset rule to ensure it does not fail when the `/data` directory is absent.