### PR TITLE
✨(dockercompose) allow switching site without losing data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,252 +316,32 @@ version: 2.1
 workflows:
   cnfpt:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-        name: check-changelog-cnfpt
-        site: cnfpt
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /cnfpt-.*/
-        name: lint-changelog--cnfpt
-        site: cnfpt
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /cnfpt-.*/
-        name: build-front-production-cnfpt
-        site: cnfpt
-    - lint-front:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: lint-front-cnfpt
-        requires:
-        - build-front-production-cnfpt
-        site: cnfpt
-    - build-back:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: build-back-cnfpt
-        site: cnfpt
-    - lint-back:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: lint-back-cnfpt
-        requires:
-        - build-back-cnfpt
-        site: cnfpt
-    - test-back:
-        filters:
-          tags:
-            only: /cnfpt-.*/
-        name: test-back-cnfpt
-        requires:
-        - build-back-cnfpt
-        site: cnfpt
-    - hub:
-        filters:
-          tags:
-            only: /^cnfpt-.*/
-        image_name: cnfpt
-        name: hub-cnfpt
-        requires:
-        - lint-front-cnfpt
-        - lint-back-cnfpt
-        site: cnfpt
+            only: /.*/
+        name: no-change-cnfpt
   demo:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-        name: check-changelog-demo
-        site: demo
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /demo-.*/
-        name: lint-changelog--demo
-        site: demo
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /demo-.*/
-        name: build-front-production-demo
-        site: demo
-    - lint-front:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: lint-front-demo
-        requires:
-        - build-front-production-demo
-        site: demo
-    - build-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: build-back-demo
-        site: demo
-    - lint-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: lint-back-demo
-        requires:
-        - build-back-demo
-        site: demo
-    - test-back:
-        filters:
-          tags:
-            only: /demo-.*/
-        name: test-back-demo
-        requires:
-        - build-back-demo
-        site: demo
-    - hub:
-        filters:
-          tags:
-            only: /^demo-.*/
-        image_name: richie-demo
-        name: hub-demo
-        requires:
-        - lint-front-demo
-        - lint-back-demo
-        site: demo
+            only: /.*/
+        name: no-change-demo
   funcorporate:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-        name: check-changelog-funcorporate
-        site: funcorporate
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /funcorporate-.*/
-        name: lint-changelog--funcorporate
-        site: funcorporate
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /funcorporate-.*/
-        name: build-front-production-funcorporate
-        site: funcorporate
-    - lint-front:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: lint-front-funcorporate
-        requires:
-        - build-front-production-funcorporate
-        site: funcorporate
-    - build-back:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: build-back-funcorporate
-        site: funcorporate
-    - lint-back:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: lint-back-funcorporate
-        requires:
-        - build-back-funcorporate
-        site: funcorporate
-    - test-back:
-        filters:
-          tags:
-            only: /funcorporate-.*/
-        name: test-back-funcorporate
-        requires:
-        - build-back-funcorporate
-        site: funcorporate
-    - hub:
-        filters:
-          tags:
-            only: /^funcorporate-.*/
-        image_name: funcorporate
-        name: hub-funcorporate
-        requires:
-        - lint-front-funcorporate
-        - lint-back-funcorporate
-        site: funcorporate
+            only: /.*/
+        name: no-change-funcorporate
   funmooc:
     jobs:
-    - check-changelog:
-        filters:
-          branches:
-            ignore: master
-        name: check-changelog-funmooc
-        site: funmooc
-    - lint-changelog:
-        filters:
-          branches:
-            ignore: master
-          tags:
-            only: /funmooc-.*/
-        name: lint-changelog--funmooc
-        site: funmooc
-    - build-front-production:
+    - no-change:
         filters:
           tags:
-            only: /funmooc-.*/
-        name: build-front-production-funmooc
-        site: funmooc
-    - lint-front:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: lint-front-funmooc
-        requires:
-        - build-front-production-funmooc
-        site: funmooc
-    - build-back:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: build-back-funmooc
-        site: funmooc
-    - lint-back:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: lint-back-funmooc
-        requires:
-        - build-back-funmooc
-        site: funmooc
-    - test-back:
-        filters:
-          tags:
-            only: /funmooc-.*/
-        name: test-back-funmooc
-        requires:
-        - build-back-funmooc
-        site: funmooc
-    - hub:
-        filters:
-          tags:
-            only: /^funmooc-.*/
-        image_name: funmooc
-        name: hub-funmooc
-        requires:
-        - lint-front-funmooc
-        - lint-back-funmooc
-        site: funmooc
+            only: /.*/
+        name: no-change-funmooc
   site-factory:
     jobs:
     - lint-git:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+RICHIE_SITE ?= funmooc
+
 # -- Terminal colors
 COLOR_INFO    = \033[0;36m
 COLOR_RESET   = \033[0m
@@ -38,7 +40,17 @@ MANAGE = $(COMPOSE_RUN_APP) python manage.py
 # -- Rules
 default: help
 
-bootstrap: env.d/aws reset data/media/.keep build-front build run migrate init ## install development dependencies
+bootstrap: \
+  env.d/aws \
+  data/media/$(RICHIE_SITE)/.keep \
+  data/db/$(RICHIE_SITE)/.keep \
+  stop \
+  build-front \
+  build \
+  run \
+  migrate \
+  init
+bootstrap:  ## install development dependencies
 .PHONY: bootstrap
 
 # == Docker
@@ -224,10 +236,15 @@ clean: ## restore repository state as it was freshly cloned
 	git clean -idx
 .PHONY: clean
 
-data/media/.keep:
+data/media/$(RICHIE_SITE)/.keep:
 	@echo 'Preparing media volume...'
-	@mkdir -p data/media
-	@touch data/media/.keep
+	@mkdir -p data/media/$(RICHIE_SITE)
+	@touch data/media/$(RICHIE_SITE)/.keep
+
+data/db/$(RICHIE_SITE)/.keep:
+	@echo 'Preparing db volume...'
+	@mkdir -p data/db/$(RICHIE_SITE)
+	@touch data/db/$(RICHIE_SITE)/.keep
 
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,14 @@ version: "3.4"
 services:
   db:
     image: postgres:9.6
+    environment:
+      - POSTGRES_DB=richie_${RICHIE_SITE:-funmooc}
     env_file:
       - "env.d/development"
     ports:
       - "5440:5432"
+    volumes:
+      - ./data/db/${RICHIE_SITE:-funmooc}:/var/lib/postgresql/data
 
   elasticsearch:
     image: fundocker/openshift-elasticsearch:6.6.2
@@ -24,14 +28,16 @@ services:
         SITE: ${RICHIE_SITE:-funmooc}
     image: "${RICHIE_SITE:-funmooc}:development"
     environment:
+      - DB_NAME=richie_${RICHIE_SITE:-funmooc}
       - DJANGO_SETTINGS_MODULE=${RICHIE_SITE:-funmooc}.settings
       - DJANGO_CONFIGURATION=Development
+      - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:-funmooc}
     env_file: env.d/development
     ports:
       - "8080:8000"
     volumes:
       - "./sites/${RICHIE_SITE:-funmooc}/src/backend:/app"
-      - "./data/media:/data/media"
+      - "./data/media/${RICHIE_SITE:-funmooc}:/data/media"
     depends_on:
       - "db"
       - "elasticsearch"
@@ -48,13 +54,15 @@ services:
     # unique and avoid collisions in parallel builds.
     image: "${RICHIE_SITE:-funmooc}:production"
     environment:
+      - DB_NAME=richie_${RICHIE_SITE:-funmooc}
       - DJANGO_SETTINGS_MODULE=${RICHIE_SITE:-funmooc}.settings
       - DJANGO_CONFIGURATION=ContinuousIntegration
+      - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:-funmooc}
     env_file: env.d/development
     ports:
       - "8000:8000"
     volumes:
-      - ./data/media:/data/media
+      - ./data/media/${RICHIE_SITE:-funmooc}:/data/media
     depends_on:
       - "db"
       - "elasticsearch"
@@ -74,7 +82,7 @@ services:
       - "8081:8081"
     volumes:
       - ./docker/files/etc/nginx/conf.d:/etc/nginx/conf.d:ro
-      - ./data/media:/data/media:ro
+      - ./data/media/${RICHIE_SITE:-funmooc}:/data/media:ro
     depends_on:
       - app
 


### PR DESCRIPTION
## Purpose

When working on several sites in parallel, we want to be able to switch site without losing the database or media files. 

## Proposal

This can be done by mounting data directories specific to each site.

Switching site can now be done by running:
```bash
$ make stop
$ . bin/activate
$ make run
```