### PR TITLE
🔧(cnfpt) change cloudfront domain to new-mooc.cnfpt.fr in production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,66 +329,11 @@ workflows:
                 name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
             - no-change:

--- a/sites/cnfpt/aws/config.tfvars
+++ b/sites/cnfpt/aws/config.tfvars
@@ -1,7 +1,7 @@
 site = "cnfpt"
 
 app_domain = {
-  production = "new.mooc.cnfpt"
+  production = "new-mooc.cnfpt.fr"
   preprod = "preprod.cnfpt.oc.openfun.fr"
   staging = "staging.cnfpt.oc.openfun.fr"
 }


### PR DESCRIPTION
## Purpose

CNFPT refused to create a record for new.mooc.cnfpt.fr and created new-mooc.cnfpt.fr.

## Proposal

Change CloudFront configuration to point to the new domain.

Note: this PR is already deployed to production :wink: 
