### PR TITLE
Enable cache with redis-sentinel for all sites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,9 @@ jobs:
             - run:
                 command: ~/.local/bin/bandit -qr .
                 name: Lint code with bandit
+            - run:
+                command: ~/.local/bin/raincoat
+                name: Lint code with raincoat
         working_directory: ~/fun/sites/<< parameters.site >>/src/backend/
     lint-bash:
         docker:
@@ -393,66 +396,11 @@ workflows:
                 name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
             - no-change:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,32 +389,252 @@ workflows:
                 site: cnfpt
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcampus
+                        only: /funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
     funcorporate:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                        only: /funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,6 +294,15 @@ jobs:
                 POSTGRES_PASSWORD: pass
                 POSTGRES_USER: richie_user
               image: circleci/postgres:9.6-alpine-ram
+            - environment:
+                ALLOW_EMPTY_PASSWORD: "yes"
+                REDIS_REPLICATION_MODE: master
+              image: docker.io/bitnami/redis:6.0-debian-10
+              name: redis-primary
+            - environment:
+                REDIS_MASTER_HOST: redis-primary
+              image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+              name: redis-sentinel
         parameters:
             site:
                 type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,11 +324,66 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-cnfpt
+                site: cnfpt
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-changelog--cnfpt
+                site: cnfpt
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-cnfpt
+                        only: /cnfpt-.*/
+                name: build-front-production-cnfpt
+                site: cnfpt
+            - lint-front:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-front-cnfpt
+                requires:
+                    - build-front-production-cnfpt
+                site: cnfpt
+            - build-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: build-back-cnfpt
+                site: cnfpt
+            - lint-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-back-cnfpt
+                requires:
+                    - build-back-cnfpt
+                site: cnfpt
+            - test-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: test-back-cnfpt
+                requires:
+                    - build-back-cnfpt
+                site: cnfpt
+            - hub:
+                filters:
+                    tags:
+                        only: /^cnfpt-.*/
+                image_name: cnfpt
+                name: hub-cnfpt
+                requires:
+                    - lint-front-cnfpt
+                    - lint-back-cnfpt
+                site: cnfpt
     demo:
         jobs:
             - no-change:

--- a/.circleci/src/jobs/@backend.yml
+++ b/.circleci/src/jobs/@backend.yml
@@ -75,6 +75,15 @@ test-back:
         POSTGRES_DB: richie
         POSTGRES_USER: richie_user
         POSTGRES_PASSWORD: pass
+    - image: docker.io/bitnami/redis:6.0-debian-10
+      name: redis-primary
+      environment:
+        ALLOW_EMPTY_PASSWORD: yes
+        REDIS_REPLICATION_MODE: master
+    - image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+      name: redis-sentinel
+      environment:
+        REDIS_MASTER_HOST: redis-primary
   working_directory: ~/fun/sites/<< parameters.site >>/src/backend
   steps:
     - checkout:

--- a/.circleci/src/jobs/@backend.yml
+++ b/.circleci/src/jobs/@backend.yml
@@ -53,6 +53,9 @@ lint-back:
     - run:
         name: Lint code with bandit
         command: ~/.local/bin/bandit -qr .
+    - run:
+        name: Lint code with raincoat
+        command: ~/.local/bin/raincoat
 
 test-back:
   parameters:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ COMPOSE_TEST_RUN     = $(COMPOSE) run --rm -e DJANGO_CONFIGURATION=Test
 COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app-dev
 WAIT_DB              = $(COMPOSE_RUN) dockerize -wait tcp://db:5432 -timeout 60s
 WAIT_ES              = $(COMPOSE_RUN) dockerize -wait tcp://elasticsearch:9200 -timeout 60s
+WAIT_SENTINEL        = $(COMPOSE_RUN) dockerize -wait tcp://redis-sentinel:26379 -wait tcp://redis-primary:6379 -timeout 20s
 
 # -- Node
 
@@ -75,6 +76,8 @@ logs: ## display app logs (follow mode)
 .PHONY: logs
 
 run: ## start the wsgi (production) or development server
+	@$(COMPOSE) up -V -d redis-sentinel
+	@$(WAIT_SENTINEL)
 	@$(COMPOSE) up -d nginx
 	@$(COMPOSE) up -d app-dev
 	@$(WAIT_DB)

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,8 @@ lint-back: \
   lint-back-black \
   lint-back-flake8 \
   lint-back-pylint \
-  lint-back-bandit
+  lint-back-bandit \
+  lint-back-raincoat
 .PHONY: lint-back
 
 lint-back-black: ## lint back-end python sources with black
@@ -178,6 +179,11 @@ lint-back-pylint: ## lint back-end python sources with pylint
 	@echo 'lint:pylint started…'
 	@$(COMPOSE_TEST_RUN_APP) pylint .
 .PHONY: lint-back-pylint
+
+lint-back-raincoat: ## lint back-end python sources with raincoat
+	@echo 'lint:raincoat started…'
+	@$(COMPOSE_TEST_RUN_APP) raincoat
+.PHONY: lint-back-raincoat
 
 lint-back-bandit: ## lint back-end python sources with bandit
 	@echo 'lint:bandit started…'

--- a/bin/pytest
+++ b/bin/pytest
@@ -2,6 +2,9 @@
 
 # source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# Recreate the redis sentinel service to avoid inconsistent state
+docker-compose up -d -V redis-sentinel
+
 docker-compose run --rm dockerize -wait tcp://db:5432 -timeout 60s
 docker-compose run --rm dockerize -wait tcp://elasticsearch:9200 -timeout 60s
 docker-compose run --rm \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     depends_on:
       - "db"
       - "elasticsearch"
+      - "redis-sentinel"
     user: ${DOCKER_USER:-1000}
 
   app:
@@ -66,6 +67,7 @@ services:
     depends_on:
       - "db"
       - "elasticsearch"
+      - "redis-sentinel"
     user: ${DOCKER_USER:-1000}
 
   nginx:
@@ -117,3 +119,16 @@ services:
       - ./aws:/app
       - ./sites/${RICHIE_SITE:-funmooc}/aws:/config
     user: ${DOCKER_USER:-1000}
+
+  redis-sentinel:
+    image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+    environment:
+      - REDIS_MASTER_HOST=redis-primary
+    depends_on:
+      - redis-primary
+
+  redis-primary:
+    image: docker.io/bitnami/redis:6.0-debian-10
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_REPLICATION_MODE=master

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Upgrade richie to 2.0.0-beta.11
 - Enable Django CMS page cache for non-staff users
+- Enable cache for content and sessions
 
 ## [0.3.0] - 2020-06-17
 

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade richie to 2.0.0-beta.11
+- Enable Django CMS page cache for non-staff users
 
 ## [0.3.0] - 2020-06-17
 

--- a/sites/cnfpt/requirements/dev.txt
+++ b/sites/cnfpt/requirements/dev.txt
@@ -9,3 +9,4 @@ pylint-django==2.0.15
 pytest==5.4.2
 pytest-cov==2.8.1
 pytest-django==3.9.0
+raincoat==1.0.1

--- a/sites/cnfpt/src/backend/base/cache.py
+++ b/sites/cnfpt/src/backend/base/cache.py
@@ -23,6 +23,7 @@ def set_page_cache(response):
     This method redefines cms.cache.page.set_page_cache to allow
     Django CMS page cache for non-staff logged-in users
     """
+    # Raincoat: pypi package: django-cms==3.7.4 path: cms/cache/page.py element: set_page_cache
 
     from django.core.cache import cache
 

--- a/sites/cnfpt/src/backend/base/cache.py
+++ b/sites/cnfpt/src/backend/base/cache.py
@@ -1,0 +1,81 @@
+"""
+This module contains cache-related utilities functions.
+"""
+
+from datetime import timedelta
+
+from django.utils.cache import (
+    add_never_cache_headers,
+    patch_response_headers,
+    patch_vary_headers,
+)
+from django.utils.timezone import now
+
+from cms.cache import _get_cache_version, _set_cache_version
+from cms.cache.page import _page_cache_key
+from cms.constants import EXPIRE_NOW, MAX_EXPIRATION_TTL
+from cms.toolbar.utils import get_toolbar_from_request
+from cms.utils.conf import get_cms_setting
+
+
+def set_page_cache(response):
+    """
+    This method redefines cms.cache.page.set_page_cache to allow
+    Django CMS page cache for non-staff logged-in users
+    """
+
+    from django.core.cache import cache
+
+    request = response._request
+    toolbar = get_toolbar_from_request(request)
+    is_staff = request.user.is_staff
+
+    if is_staff or toolbar._cache_disabled or not get_cms_setting("PAGE_CACHE"):
+        add_never_cache_headers(response)
+        return response
+
+    # This *must* be TZ-aware
+    timestamp = now()
+
+    placeholders = toolbar.content_renderer.get_rendered_placeholders()
+    # Checks if there's a plugin using the legacy "cache = False"
+    placeholder_ttl_list = []
+    vary_cache_on_set = set()
+    for ph in placeholders:
+        # get_cache_expiration() always returns:
+        #     EXPIRE_NOW <= int <= MAX_EXPIRATION_IN_SECONDS
+        ttl = ph.get_cache_expiration(request, timestamp)
+        vary_cache_on = ph.get_vary_cache_on(request)
+
+        placeholder_ttl_list.append(ttl)
+        if ttl and vary_cache_on:
+            # We're only interested in vary headers if they come from
+            # a cache-able placeholder.
+            vary_cache_on_set |= set(vary_cache_on)
+
+    if EXPIRE_NOW not in placeholder_ttl_list:
+        if placeholder_ttl_list:
+            min_placeholder_ttl = min(x for x in placeholder_ttl_list)
+        else:
+            # Should only happen when there are no placeholders at all
+            min_placeholder_ttl = MAX_EXPIRATION_TTL
+        ttl = min(get_cms_setting("CACHE_DURATIONS")["content"], min_placeholder_ttl)
+
+        if ttl > 0:
+            # Adds expiration, etc. to headers
+            patch_response_headers(response, cache_timeout=ttl)
+            patch_vary_headers(response, sorted(vary_cache_on_set))
+
+            version = _get_cache_version()
+            # We also store the absolute expiration timestamp to avoid
+            # recomputing it on cache-reads.
+            expires_datetime = timestamp + timedelta(seconds=ttl)
+            cache.set(
+                _page_cache_key(request),
+                (response.content, response._headers, expires_datetime,),
+                ttl,
+                version=version,
+            )
+            # See note in invalidate_cms_page_cache()
+            _set_cache_version(version)
+    return response

--- a/sites/cnfpt/src/backend/cnfpt/settings.py
+++ b/sites/cnfpt/src/backend/cnfpt/settings.py
@@ -373,30 +373,30 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     )
 
     # Cache
-    CACHES = {
-        "default": values.DictValue({
-            "BACKEND": values.Value(
-                "django_redis.cache.RedisCache",
-                environ_name="CACHE_DEFAULT_BACKEND",
-                environ_prefix=None,
-            ),
-            "LOCATION": values.Value(
-                "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
-                environ_name="CACHE_DEFAULT_LOCATION",
-                environ_prefix=None,
-            ),
-            "OPTIONS": values.DictValue(
-                {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
-                environ_name="CACHE_DEFAULT_OPTIONS",
-                environ_prefix=None,
-            ),
-            "TIMEOUT": values.IntegerValue(
-                300,
-                environ_name="CACHE_DEFAULT_TIMEOUT",
-                environ_prefix=None,
-            ),
-        })
-    }
+    CACHES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "django_redis.cache.RedisCache",
+                    environ_name="CACHE_DEFAULT_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                    environ_name="CACHE_DEFAULT_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    environ_name="CACHE_DEFAULT_OPTIONS",
+                    environ_prefix=None,
+                ),
+                "TIMEOUT": values.IntegerValue(
+                    300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None,
+                ),
+            }
+        }
+    )
 
     # For more details about CMS_CACHE_DURATION, see :
     # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations

--- a/sites/cnfpt/src/backend/cnfpt/settings.py
+++ b/sites/cnfpt/src/backend/cnfpt/settings.py
@@ -214,6 +214,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     ]
 
     MIDDLEWARE = (
+        "django.middleware.cache.UpdateCacheMiddleware",
         "cms.middleware.utils.ApphookReloadMiddleware",
         "django.middleware.security.SecurityMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
@@ -229,6 +230,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "cms.middleware.toolbar.ToolbarMiddleware",
         "cms.middleware.language.LanguageCookieMiddleware",
         "dj_pagination.middleware.PaginationMiddleware",
+        "django.middleware.cache.FetchFromCacheMiddleware",
     )
 
     INSTALLED_APPS = (
@@ -370,6 +372,41 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
     )
 
+    # Cache
+    CACHES = {
+        "default": values.DictValue({
+            "BACKEND": values.Value(
+                "django_redis.cache.RedisCache",
+                environ_name="CACHE_DEFAULT_BACKEND",
+                environ_prefix=None,
+            ),
+            "LOCATION": values.Value(
+                "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                environ_name="CACHE_DEFAULT_LOCATION",
+                environ_prefix=None,
+            ),
+            "OPTIONS": values.DictValue(
+                {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                environ_name="CACHE_DEFAULT_OPTIONS",
+                environ_prefix=None,
+            ),
+            "TIMEOUT": values.IntegerValue(
+                300,
+                environ_name="CACHE_DEFAULT_TIMEOUT",
+                environ_prefix=None,
+            ),
+        })
+    }
+
+    # For more details about CMS_CACHE_DURATION, see :
+    # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
+    CMS_CACHE_DURATIONS = values.DictValue(
+        {"menus": 3600, "content": 86400, "permissions": 86400}
+    )
+
+    # Sessions
+    SESSION_ENGINE = values.Value("django.contrib.sessions.backends.cache")
+
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
@@ -418,6 +455,13 @@ class Development(Base):
 
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "dev-cache",
+        }
+    }
 
 
 class Test(Base):

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade richie to 2.0.0-beta.11
+- Enable Django CMS page cache for non-staff users
+- Enable cache for content and sessions
 
 ## [2.0.0-beta.8] - 2020-06-17
 

--- a/sites/demo/requirements/dev.txt
+++ b/sites/demo/requirements/dev.txt
@@ -9,3 +9,4 @@ pylint-django==2.0.15
 pytest==5.4.2
 pytest-cov==2.8.1
 pytest-django==3.9.0
+raincoat==1.0.1

--- a/sites/demo/src/backend/base/admin.py
+++ b/sites/demo/src/backend/base/admin.py
@@ -1,0 +1,15 @@
+"""Admin overrides for the demo site."""
+
+import cms.cache.page
+
+from .cache import set_page_cache
+
+# Django CMS disables page cache for authenticated users
+# (See https://github.com/divio/django-cms/blob/3.7.4/cms/cache/page.py#L38)
+#
+# In our case, since most of our users will be authenticated and be served the
+# same content, this is a problem. That's why we are monkey patching the
+# function `cms.cache.page.set_page_cache`.
+# All non-staff users will benefit from page cache.
+
+cms.cache.page.set_page_cache = set_page_cache

--- a/sites/demo/src/backend/base/cache.py
+++ b/sites/demo/src/backend/base/cache.py
@@ -1,0 +1,82 @@
+"""
+This module contains cache-related utilities functions.
+"""
+
+from datetime import timedelta
+
+from django.utils.cache import (
+    add_never_cache_headers,
+    patch_response_headers,
+    patch_vary_headers,
+)
+from django.utils.timezone import now
+
+from cms.cache import _get_cache_version, _set_cache_version
+from cms.cache.page import _page_cache_key
+from cms.constants import EXPIRE_NOW, MAX_EXPIRATION_TTL
+from cms.toolbar.utils import get_toolbar_from_request
+from cms.utils.conf import get_cms_setting
+
+
+def set_page_cache(response):
+    """
+    This method redefines cms.cache.page.set_page_cache to allow
+    Django CMS page cache for non-staff logged-in users
+    """
+    # Raincoat: pypi package: django-cms==3.7.4 path: cms/cache/page.py element: set_page_cache
+
+    from django.core.cache import cache
+
+    request = response._request
+    toolbar = get_toolbar_from_request(request)
+    is_staff = request.user.is_staff
+
+    if is_staff or toolbar._cache_disabled or not get_cms_setting("PAGE_CACHE"):
+        add_never_cache_headers(response)
+        return response
+
+    # This *must* be TZ-aware
+    timestamp = now()
+
+    placeholders = toolbar.content_renderer.get_rendered_placeholders()
+    # Checks if there's a plugin using the legacy "cache = False"
+    placeholder_ttl_list = []
+    vary_cache_on_set = set()
+    for ph in placeholders:
+        # get_cache_expiration() always returns:
+        #     EXPIRE_NOW <= int <= MAX_EXPIRATION_IN_SECONDS
+        ttl = ph.get_cache_expiration(request, timestamp)
+        vary_cache_on = ph.get_vary_cache_on(request)
+
+        placeholder_ttl_list.append(ttl)
+        if ttl and vary_cache_on:
+            # We're only interested in vary headers if they come from
+            # a cache-able placeholder.
+            vary_cache_on_set |= set(vary_cache_on)
+
+    if EXPIRE_NOW not in placeholder_ttl_list:
+        if placeholder_ttl_list:
+            min_placeholder_ttl = min(x for x in placeholder_ttl_list)
+        else:
+            # Should only happen when there are no placeholders at all
+            min_placeholder_ttl = MAX_EXPIRATION_TTL
+        ttl = min(get_cms_setting("CACHE_DURATIONS")["content"], min_placeholder_ttl)
+
+        if ttl > 0:
+            # Adds expiration, etc. to headers
+            patch_response_headers(response, cache_timeout=ttl)
+            patch_vary_headers(response, sorted(vary_cache_on_set))
+
+            version = _get_cache_version()
+            # We also store the absolute expiration timestamp to avoid
+            # recomputing it on cache-reads.
+            expires_datetime = timestamp + timedelta(seconds=ttl)
+            cache.set(
+                _page_cache_key(request),
+                (response.content, response._headers, expires_datetime,),
+                ttl,
+                version=version,
+            )
+            # See note in invalidate_cms_page_cache()
+            _set_cache_version(version)
+    return response

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -220,6 +220,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     ]
 
     MIDDLEWARE = (
+        "django.middleware.cache.UpdateCacheMiddleware",
         "cms.middleware.utils.ApphookReloadMiddleware",
         "django.middleware.security.SecurityMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
@@ -235,6 +236,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "cms.middleware.toolbar.ToolbarMiddleware",
         "cms.middleware.language.LanguageCookieMiddleware",
         "dj_pagination.middleware.PaginationMiddleware",
+        "django.middleware.cache.FetchFromCacheMiddleware",
     )
 
     INSTALLED_APPS = (
@@ -376,6 +378,41 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
     )
 
+    # Cache
+    CACHES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "django_redis.cache.RedisCache",
+                    environ_name="CACHE_DEFAULT_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                    environ_name="CACHE_DEFAULT_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    environ_name="CACHE_DEFAULT_OPTIONS",
+                    environ_prefix=None,
+                ),
+                "TIMEOUT": values.IntegerValue(
+                    300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None,
+                ),
+            }
+        }
+    )
+
+    # For more details about CMS_CACHE_DURATION, see :
+    # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
+    CMS_CACHE_DURATIONS = values.DictValue(
+        {"menus": 3600, "content": 86400, "permissions": 86400}
+    )
+
+    # Sessions
+    SESSION_ENGINE = values.Value("django.contrib.sessions.backends.cache")
+
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
@@ -424,6 +461,12 @@ class Development(Base):
 
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache"
+        }
+    }
 
 
 class Test(Base):

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgrade richie to 2.0.0-beta.11
 - Update theme to fit to requirements (primary and secondary color change,
   logo, favicon).
+- Enable cache for content and sessions
+- Enable Django CMS page cache for non-staff users
 
 ## [0.1.0] - 2020-07-23
 

--- a/sites/funcampus/requirements/dev.txt
+++ b/sites/funcampus/requirements/dev.txt
@@ -9,3 +9,4 @@ pylint-django==2.0.15
 pytest==5.4.2
 pytest-cov==2.8.1
 pytest-django==3.9.0
+raincoat==1.0.1

--- a/sites/funcampus/src/backend/base/cache.py
+++ b/sites/funcampus/src/backend/base/cache.py
@@ -1,0 +1,82 @@
+"""
+This module contains cache-related utilities functions.
+"""
+
+from datetime import timedelta
+
+from django.utils.cache import (
+    add_never_cache_headers,
+    patch_response_headers,
+    patch_vary_headers,
+)
+from django.utils.timezone import now
+
+from cms.cache import _get_cache_version, _set_cache_version
+from cms.cache.page import _page_cache_key
+from cms.constants import EXPIRE_NOW, MAX_EXPIRATION_TTL
+from cms.toolbar.utils import get_toolbar_from_request
+from cms.utils.conf import get_cms_setting
+
+
+def set_page_cache(response):
+    """
+    This method redefines cms.cache.page.set_page_cache to allow
+    Django CMS page cache for non-staff logged-in users
+    """
+    # Raincoat: pypi package: django-cms==3.7.4 path: cms/cache/page.py element: set_page_cache
+
+    from django.core.cache import cache
+
+    request = response._request
+    toolbar = get_toolbar_from_request(request)
+    is_staff = request.user.is_staff
+
+    if is_staff or toolbar._cache_disabled or not get_cms_setting("PAGE_CACHE"):
+        add_never_cache_headers(response)
+        return response
+
+    # This *must* be TZ-aware
+    timestamp = now()
+
+    placeholders = toolbar.content_renderer.get_rendered_placeholders()
+    # Checks if there's a plugin using the legacy "cache = False"
+    placeholder_ttl_list = []
+    vary_cache_on_set = set()
+    for ph in placeholders:
+        # get_cache_expiration() always returns:
+        #     EXPIRE_NOW <= int <= MAX_EXPIRATION_IN_SECONDS
+        ttl = ph.get_cache_expiration(request, timestamp)
+        vary_cache_on = ph.get_vary_cache_on(request)
+
+        placeholder_ttl_list.append(ttl)
+        if ttl and vary_cache_on:
+            # We're only interested in vary headers if they come from
+            # a cache-able placeholder.
+            vary_cache_on_set |= set(vary_cache_on)
+
+    if EXPIRE_NOW not in placeholder_ttl_list:
+        if placeholder_ttl_list:
+            min_placeholder_ttl = min(x for x in placeholder_ttl_list)
+        else:
+            # Should only happen when there are no placeholders at all
+            min_placeholder_ttl = MAX_EXPIRATION_TTL
+        ttl = min(get_cms_setting("CACHE_DURATIONS")["content"], min_placeholder_ttl)
+
+        if ttl > 0:
+            # Adds expiration, etc. to headers
+            patch_response_headers(response, cache_timeout=ttl)
+            patch_vary_headers(response, sorted(vary_cache_on_set))
+
+            version = _get_cache_version()
+            # We also store the absolute expiration timestamp to avoid
+            # recomputing it on cache-reads.
+            expires_datetime = timestamp + timedelta(seconds=ttl)
+            cache.set(
+                _page_cache_key(request),
+                (response.content, response._headers, expires_datetime,),
+                ttl,
+                version=version,
+            )
+            # See note in invalidate_cms_page_cache()
+            _set_cache_version(version)
+    return response

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -220,6 +220,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     ]
 
     MIDDLEWARE = (
+        "django.middleware.cache.UpdateCacheMiddleware",
         "cms.middleware.utils.ApphookReloadMiddleware",
         "django.middleware.security.SecurityMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
@@ -235,6 +236,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "cms.middleware.toolbar.ToolbarMiddleware",
         "cms.middleware.language.LanguageCookieMiddleware",
         "dj_pagination.middleware.PaginationMiddleware",
+        "django.middleware.cache.FetchFromCacheMiddleware",
     )
 
     # Django applications from the highest priority to the lowest
@@ -452,6 +454,41 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
     )
 
+    # Cache
+    CACHES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "django_redis.cache.RedisCache",
+                    environ_name="CACHE_DEFAULT_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                    environ_name="CACHE_DEFAULT_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    environ_name="CACHE_DEFAULT_OPTIONS",
+                    environ_prefix=None,
+                ),
+                "TIMEOUT": values.IntegerValue(
+                    300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None,
+                ),
+            }
+        }
+    )
+
+    # For more details about CMS_CACHE_DURATION, see :
+    # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
+    CMS_CACHE_DURATIONS = values.DictValue(
+        {"menus": 3600, "content": 86400, "permissions": 86400}
+    )
+
+    # Sessions
+    SESSION_ENGINE = values.Value("django.contrib.sessions.backends.cache")
+
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
@@ -500,6 +537,12 @@ class Development(Base):
 
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
 
 
 class Test(Base):

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade richie to 2.0.0-beta.11
+- Enable cache for content and sessions
+- Enable Django CMS page cache for non-staff users
 
 ## [0.4.0] - 2020-06-17
 

--- a/sites/funcorporate/requirements/dev.txt
+++ b/sites/funcorporate/requirements/dev.txt
@@ -9,3 +9,4 @@ pylint-django==2.0.15
 pytest==5.4.2
 pytest-cov==2.8.1
 pytest-django==3.9.0
+raincoat==1.0.1

--- a/sites/funcorporate/src/backend/base/cache.py
+++ b/sites/funcorporate/src/backend/base/cache.py
@@ -1,0 +1,82 @@
+"""
+This module contains cache-related utilities functions.
+"""
+
+from datetime import timedelta
+
+from django.utils.cache import (
+    add_never_cache_headers,
+    patch_response_headers,
+    patch_vary_headers,
+)
+from django.utils.timezone import now
+
+from cms.cache import _get_cache_version, _set_cache_version
+from cms.cache.page import _page_cache_key
+from cms.constants import EXPIRE_NOW, MAX_EXPIRATION_TTL
+from cms.toolbar.utils import get_toolbar_from_request
+from cms.utils.conf import get_cms_setting
+
+
+def set_page_cache(response):
+    """
+    This method redefines cms.cache.page.set_page_cache to allow
+    Django CMS page cache for non-staff logged-in users
+    """
+    # Raincoat: pypi package: django-cms==3.7.4 path: cms/cache/page.py element: set_page_cache
+
+    from django.core.cache import cache
+
+    request = response._request
+    toolbar = get_toolbar_from_request(request)
+    is_staff = request.user.is_staff
+
+    if is_staff or toolbar._cache_disabled or not get_cms_setting("PAGE_CACHE"):
+        add_never_cache_headers(response)
+        return response
+
+    # This *must* be TZ-aware
+    timestamp = now()
+
+    placeholders = toolbar.content_renderer.get_rendered_placeholders()
+    # Checks if there's a plugin using the legacy "cache = False"
+    placeholder_ttl_list = []
+    vary_cache_on_set = set()
+    for ph in placeholders:
+        # get_cache_expiration() always returns:
+        #     EXPIRE_NOW <= int <= MAX_EXPIRATION_IN_SECONDS
+        ttl = ph.get_cache_expiration(request, timestamp)
+        vary_cache_on = ph.get_vary_cache_on(request)
+
+        placeholder_ttl_list.append(ttl)
+        if ttl and vary_cache_on:
+            # We're only interested in vary headers if they come from
+            # a cache-able placeholder.
+            vary_cache_on_set |= set(vary_cache_on)
+
+    if EXPIRE_NOW not in placeholder_ttl_list:
+        if placeholder_ttl_list:
+            min_placeholder_ttl = min(x for x in placeholder_ttl_list)
+        else:
+            # Should only happen when there are no placeholders at all
+            min_placeholder_ttl = MAX_EXPIRATION_TTL
+        ttl = min(get_cms_setting("CACHE_DURATIONS")["content"], min_placeholder_ttl)
+
+        if ttl > 0:
+            # Adds expiration, etc. to headers
+            patch_response_headers(response, cache_timeout=ttl)
+            patch_vary_headers(response, sorted(vary_cache_on_set))
+
+            version = _get_cache_version()
+            # We also store the absolute expiration timestamp to avoid
+            # recomputing it on cache-reads.
+            expires_datetime = timestamp + timedelta(seconds=ttl)
+            cache.set(
+                _page_cache_key(request),
+                (response.content, response._headers, expires_datetime,),
+                ttl,
+                version=version,
+            )
+            # See note in invalidate_cms_page_cache()
+            _set_cache_version(version)
+    return response

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -216,6 +216,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     ]
 
     MIDDLEWARE = (
+        "django.middleware.cache.UpdateCacheMiddleware",
         "cms.middleware.utils.ApphookReloadMiddleware",
         "django.middleware.security.SecurityMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
@@ -231,6 +232,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "cms.middleware.toolbar.ToolbarMiddleware",
         "cms.middleware.language.LanguageCookieMiddleware",
         "dj_pagination.middleware.PaginationMiddleware",
+        "django.middleware.cache.FetchFromCacheMiddleware",
     )
 
     # Django applications from the highest priority to the lowest
@@ -373,6 +375,41 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
     )
 
+    # Cache
+    CACHES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "django_redis.cache.RedisCache",
+                    environ_name="CACHE_DEFAULT_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                    environ_name="CACHE_DEFAULT_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    environ_name="CACHE_DEFAULT_OPTIONS",
+                    environ_prefix=None,
+                ),
+                "TIMEOUT": values.IntegerValue(
+                    300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None,
+                ),
+            }
+        }
+    )
+
+    # For more details about CMS_CACHE_DURATION, see :
+    # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
+    CMS_CACHE_DURATIONS = values.DictValue(
+        {"menus": 3600, "content": 86400, "permissions": 86400}
+    )
+
+    # Sessions
+    SESSION_ENGINE = values.Value("django.contrib.sessions.backends.cache")
+
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
@@ -421,6 +458,12 @@ class Development(Base):
 
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
+
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
 
 
 class Test(Base):

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - More accessible category badges color everywhere.
 - Adapt bullet list checkmark icon color to funmooc theme.
 - Removed header bottom border.
+- Enable Django CMS page cache for non-staff users
+- Enable cache for content and sessions
 
 ## [0.12.0] - 2020-06-17
 

--- a/sites/funmooc/requirements/dev.txt
+++ b/sites/funmooc/requirements/dev.txt
@@ -9,3 +9,4 @@ pylint-django==2.0.15
 pytest==5.4.2
 pytest-cov==2.8.1
 pytest-django==3.9.0
+raincoat==1.0.1

--- a/sites/funmooc/src/backend/base/cache.py
+++ b/sites/funmooc/src/backend/base/cache.py
@@ -1,0 +1,82 @@
+"""
+This module contains cache-related utilities functions.
+"""
+
+from datetime import timedelta
+
+from django.utils.cache import (
+    add_never_cache_headers,
+    patch_response_headers,
+    patch_vary_headers,
+)
+from django.utils.timezone import now
+
+from cms.cache import _get_cache_version, _set_cache_version
+from cms.cache.page import _page_cache_key
+from cms.constants import EXPIRE_NOW, MAX_EXPIRATION_TTL
+from cms.toolbar.utils import get_toolbar_from_request
+from cms.utils.conf import get_cms_setting
+
+
+def set_page_cache(response):
+    """
+    This method redefines cms.cache.page.set_page_cache to allow
+    Django CMS page cache for non-staff logged-in users
+    """
+    # Raincoat: pypi package: django-cms==3.7.4 path: cms/cache/page.py element: set_page_cache
+
+    from django.core.cache import cache
+
+    request = response._request
+    toolbar = get_toolbar_from_request(request)
+    is_staff = request.user.is_staff
+
+    if is_staff or toolbar._cache_disabled or not get_cms_setting("PAGE_CACHE"):
+        add_never_cache_headers(response)
+        return response
+
+    # This *must* be TZ-aware
+    timestamp = now()
+
+    placeholders = toolbar.content_renderer.get_rendered_placeholders()
+    # Checks if there's a plugin using the legacy "cache = False"
+    placeholder_ttl_list = []
+    vary_cache_on_set = set()
+    for ph in placeholders:
+        # get_cache_expiration() always returns:
+        #     EXPIRE_NOW <= int <= MAX_EXPIRATION_IN_SECONDS
+        ttl = ph.get_cache_expiration(request, timestamp)
+        vary_cache_on = ph.get_vary_cache_on(request)
+
+        placeholder_ttl_list.append(ttl)
+        if ttl and vary_cache_on:
+            # We're only interested in vary headers if they come from
+            # a cache-able placeholder.
+            vary_cache_on_set |= set(vary_cache_on)
+
+    if EXPIRE_NOW not in placeholder_ttl_list:
+        if placeholder_ttl_list:
+            min_placeholder_ttl = min(x for x in placeholder_ttl_list)
+        else:
+            # Should only happen when there are no placeholders at all
+            min_placeholder_ttl = MAX_EXPIRATION_TTL
+        ttl = min(get_cms_setting("CACHE_DURATIONS")["content"], min_placeholder_ttl)
+
+        if ttl > 0:
+            # Adds expiration, etc. to headers
+            patch_response_headers(response, cache_timeout=ttl)
+            patch_vary_headers(response, sorted(vary_cache_on_set))
+
+            version = _get_cache_version()
+            # We also store the absolute expiration timestamp to avoid
+            # recomputing it on cache-reads.
+            expires_datetime = timestamp + timedelta(seconds=ttl)
+            cache.set(
+                _page_cache_key(request),
+                (response.content, response._headers, expires_datetime,),
+                ttl,
+                version=version,
+            )
+            # See note in invalidate_cms_page_cache()
+            _set_cache_version(version)
+    return response


### PR DESCRIPTION
## Purpose

We want to improve performances of our sites by enabling content and session cache.

## Proposal

I made a POC with the `cnfpt` site.
When approved, we should do this on all sites.

- [x] Upgrade richie to a version > 2.0.0-beta.9 (with sentinel support)
- [x] Monkey patch Django CMS to enable page cache for non-staff users
- [x] Enable Django cache (`CACHES` setting + middlewares)
- [x] Increase Django CMS cache duration
- [x] Use cache for sessions (with the [`cached`](https://docs.djangoproject.com/en/3.0/topics/http/sessions/#using-cached-sessions) `SESSION_ENGINE`)

