### PR TITLE
Fix cross domain requests for static files with a querystring

### DIFF
--- a/aws/cloudfront.tf
+++ b/aws/cloudfront.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "richie_cloudfront_distribution" {
     target_origin_id = local.s3_static_origin_id
 
     forwarded_values {
-      query_string = false
+      query_string = true
       headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Authorization", "Origin"]
 
       cookies {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     user: ${DOCKER_USER:-1000}
 
   terraform:
-    image: hashicorp/terraform:latest
+    image: hashicorp/terraform:0.12.29
     environment:
       - TF_VAR_SITE=${RICHIE_SITE:-funmooc}
       - TF_DATA_DIR=/config


### PR DESCRIPTION
## Purpose

Some static files are called with a query string. It breaks the effect of CORS headers to allow cross domain requests when static files are placed behing a CDN.

## Proposal

Passing the query string to the origin fixes the issue.
