### PR TITLE
🔖(chore) bump demo to 2.0.0-beta.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,66 +327,11 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-cnfpt
-                site: cnfpt
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-changelog--cnfpt
-                site: cnfpt
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-front-production-cnfpt
-                site: cnfpt
-            - lint-front:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-front-cnfpt
-                requires:
-                    - build-front-production-cnfpt
-                site: cnfpt
-            - build-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: build-back-cnfpt
-                site: cnfpt
-            - lint-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - test-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: test-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - hub:
-                filters:
-                    tags:
-                        only: /^cnfpt-.*/
-                image_name: cnfpt
-                name: hub-cnfpt
-                requires:
-                    - lint-front-cnfpt
-                    - lint-back-cnfpt
-                site: cnfpt
+                        only: /.*/
+                name: no-change-cnfpt
     demo:
         jobs:
             - check-changelog:
@@ -451,190 +396,25 @@ workflows:
                 site: demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funmooc
-                site: funmooc
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-front-funmooc
-                requires:
-                    - build-front-production-funmooc
-                site: funmooc
-            - build-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - test-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: test-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - hub:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
-                requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-beta.11] - 2020-08-20
+
 ### Changed
 
 - Upgrade richie to 2.0.0-beta.11
@@ -32,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 First demo image for richie to 2.0.0-beta.7
 
-[unreleased]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.8...HEAD
+[unreleased]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.11...HEAD
+[2.0.0-beta.11]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.8...demo-2.0.0-beta.11
 [2.0.0-beta.8]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.7...demo-2.0.0-beta.8
 [2.0.0-beta.7]: https://github.com/openfun/richie-site-factory/releases/tag/demo-2.0.0-beta.7

--- a/sites/demo/src/backend/demo/__init__.py
+++ b/sites/demo/src/backend/demo/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.8"
+__version__ = "2.0.0-beta.11"

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.11",
   "description": "Richie demo site on https://demo.richie.education",
   "scripts": {
     "prettier": "prettier '**/*.+(css|scss)'",


### PR DESCRIPTION
## Changed

- Upgrade richie to 2.0.0-beta.11
- Enable Django CMS page cache for non-staff users
- Enable cache for content and sessions

## Fixed

- Fix translation overrides by configuring the specific "locale" directory