### PR TITLE
Customize social networks and filters for funcampus and funcorporate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,32 +327,252 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-cnfpt
+                site: cnfpt
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-changelog--cnfpt
+                site: cnfpt
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-cnfpt
+                        only: /cnfpt-.*/
+                name: build-front-production-cnfpt
+                site: cnfpt
+            - lint-front:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-front-cnfpt
+                requires:
+                    - build-front-production-cnfpt
+                site: cnfpt
+            - build-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: build-back-cnfpt
+                site: cnfpt
+            - lint-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-back-cnfpt
+                requires:
+                    - build-back-cnfpt
+                site: cnfpt
+            - test-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: test-back-cnfpt
+                requires:
+                    - build-back-cnfpt
+                site: cnfpt
+            - hub:
+                filters:
+                    tags:
+                        only: /^cnfpt-.*/
+                image_name: cnfpt
+                name: hub-cnfpt
+                requires:
+                    - lint-front-cnfpt
+                    - lint-back-cnfpt
+                site: cnfpt
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcampus
+                        only: /funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
     funcorporate:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                        only: /funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
             - check-changelog:

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ COPY --from=front-builder /builder/src/backend/base/static/richie /app/base/stat
 
 WORKDIR /app
 
+# Make sure .mo files are up-to-date
+RUN mkdir -p locale && python manage.py compilemessages
+
 # Gunicorn
 RUN mkdir -p /usr/local/etc/gunicorn
 COPY ./docker/files/usr/local/etc/gunicorn/app.py /usr/local/etc/gunicorn/app.py

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add i18n messages compilation in the DockerFile so translations are ready
+
 ## [0.4.0] - 2020-08-20
 
 ### Changed

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add i18n messages compilation in the DockerFile so translations are ready
+
 ## [2.0.0-beta.11] - 2020-08-20
 
 ### Changed

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add i18n messages compilation in the DockerFile so translations are ready
+
 ## [0.2.0] - 2020-08-20
 
 ### Changed

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Customize filters visible on the search page
 - Customize social networks links
 
 ### Fixed

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Customize social networks links
+
 ### Fixed
 
 - Add i18n messages compilation in the DockerFile so translations are ready

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -288,39 +288,31 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "django.contrib.messages",
     )
 
-    # Filters
+    # Search
     RICHIE_FILTERS_CONFIGURATION = [
         (
-            "richie.apps.search.filter_definitions.NestingWrapper",
+            "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
             {
-                "name": "course_runs",
-                "filters": [
-                    (
-                        "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
-                        {
-                            "human_name": _("Languages"),
-                            # There are too many available languages to show them all, all the
-                            # time.
-                            # Eg. 200 languages, 190+ of which will have 0 matching courses.
-                            "min_doc_count": 1,
-                            "name": "languages",
-                            "position": 5,
-                            "sorting": "count",
-                        },
-                    ),
-                ],
+                "human_name": _("Diplomas"),
+                "is_autocompletable": True,
+                "is_searchable": True,
+                "min_doc_count": 0,
+                "name": "diplomas",
+                "position": 1,
+                "reverse_id": "diplomas",
+                "term": "categories",
             },
         ),
         (
             "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
             {
-                "human_name": _("Subjects"),
+                "human_name": _("Domains and mentions"),
                 "is_autocompletable": True,
                 "is_searchable": True,
                 "min_doc_count": 0,
-                "name": "subjects",
+                "name": "domains",
                 "position": 2,
-                "reverse_id": "subjects",
+                "reverse_id": "domains",
                 "term": "categories",
             },
         ),
@@ -340,25 +332,14 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         (
             "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
             {
-                "human_name": _("Organizations"),
+                "human_name": _("Skills"),
                 "is_autocompletable": True,
                 "is_searchable": True,
                 "min_doc_count": 0,
-                "name": "organizations",
+                "name": "skills",
                 "position": 4,
-                "reverse_id": "organizations",
-            },
-        ),
-        (
-            "richie.apps.search.filter_definitions.IndexableFilterDefinition",
-            {
-                "human_name": _("Persons"),
-                "is_autocompletable": True,
-                "is_searchable": True,
-                "min_doc_count": 0,
-                "name": "persons",
-                "position": 5,
-                "reverse_id": "persons",
+                "reverse_id": "skills",
+                "term": "categories",
             },
         ),
     ]

--- a/sites/funcampus/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funcampus/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,106 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-25 18:48+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: base/admin.py:34
+msgid "Unsorted uploads are not allowed."
+msgstr "Les téléchargements non classés sont interdits"
+
+#: funcampus/settings.py:296
+msgid "Diplomas"
+msgstr "Diplômes"
+
+#: funcampus/settings.py:309
+msgid "Domains and mentions"
+msgstr "Domaines et mentions"
+
+#: funcampus/settings.py:322
+msgid "Levels"
+msgstr "Niveaux"
+
+#: funcampus/settings.py:335
+msgid "Skills"
+msgstr "Compétences"
+
+#: funcampus/settings.py:355 funcampus/settings.py:370
+msgid "English"
+msgstr "Anglais"
+
+#: funcampus/settings.py:355 funcampus/settings.py:378
+msgid "French"
+msgstr "Français"
+
+#: templates/richie/base.html:19
+msgid "Courses that enrich academic education"
+msgstr "Des formations pour enrichir les cursus"
+
+#: templates/social-networks/blogpost-badges.html:3
+#, python-format
+msgid "FUN Campus news: %(title)s"
+msgstr "Actualité FUN Campus: %(title)s"
+
+#: templates/social-networks/blogpost-badges.html:4
+#, python-format
+msgid "FUN Campus news: %(title)s %(url)s"
+msgstr "Actualité FUN Campus: %(title)s %(url)s"
+
+#: templates/social-networks/blogpost-badges.html:10
+#: templates/social-networks/course-badges.html:10
+msgid "Share on Facebook"
+msgstr "Partager sur Facebook"
+
+#: templates/social-networks/blogpost-badges.html:20
+#: templates/social-networks/course-badges.html:20
+msgid "Share on Twitter"
+msgstr "Partager sur Twitter"
+
+#: templates/social-networks/blogpost-badges.html:30
+#: templates/social-networks/course-badges.html:30
+msgid "Share on Linkedin"
+msgstr "Partager sur Linkedin"
+
+#: templates/social-networks/blogpost-badges.html:40
+#: templates/social-networks/course-badges.html:40
+msgid "Share by Email"
+msgstr "Partager par Email"
+
+#: templates/social-networks/course-badges.html:3
+msgid "Follow a course online with FUN Campus"
+msgstr "Suivre un cours en ligne avec FUN Campus"
+
+#: templates/social-networks/course-badges.html:4
+#, python-format
+msgid "I just enrolled to the course \"%(title)s\" with FUN Campus: %(url)s"
+msgstr "Je viens de m'inscrire au cours \"%(title)s\" sur FUN Campus: %(url)s"
+
+#: templates/social-networks/footer-badges.html:8
+msgid "Facebook"
+msgstr "Facebook"
+
+#: templates/social-networks/footer-badges.html:16
+msgid "Twitter page"
+msgstr "Page Twitter"
+
+#: templates/social-networks/footer-badges.html:19
+msgid "Twitter"
+msgstr "Twitter"
+
+#: templates/social-networks/footer-badges.html:27
+#: templates/social-networks/footer-badges.html:30
+msgid "Linkedin"
+msgstr "Linkedin"

--- a/sites/funcampus/src/backend/templates/richie/base.html
+++ b/sites/funcampus/src/backend/templates/richie/base.html
@@ -16,5 +16,5 @@
 {% block userlogin %}{% endblock userlogin %}
 
 {% block body_footer_title %}
-    <p class="body-footer__title">{% trans "Des formations pour enrichir les cursus" %}</p>
+    <p class="body-footer__title">{% trans "Courses that enrich academic education" %}</p>
 {% endblock body_footer_title %}

--- a/sites/funcampus/src/backend/templates/social-networks/blogpost-badges.html
+++ b/sites/funcampus/src/backend/templates/social-networks/blogpost-badges.html
@@ -1,0 +1,48 @@
+{% load i18n static %}{% spaceless %}
+{% with full_page_url=SITE.web_url|add:page_url %}
+    {% blocktrans with title=page_title asvar mailto_subject %}FUN Campus news: {{ title }}{% endblocktrans %}
+    {% blocktrans with title=page_title|safe url=full_page_url asvar shared_sentence %}FUN Campus news: {{ title }} {{ url }}{% endblocktrans %}
+    <div class="social-network-badges">
+        <a
+            href="https://www.facebook.com/share.php?u={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Facebook" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-facebook" />
+            </svg>
+        </a>
+        <a
+            href="https://twitter.com/intent/tweet?text={{ shared_sentence|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Twitter" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-twitter" />
+            </svg>
+        </a>
+        <a
+            href="https://www.linkedin.com/sharing/share-offsite/?url={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Linkedin" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-linkedin" />
+            </svg>
+        </a>
+        <a
+            href="mailto:?subject={{ mailto_subject|urlencode }}&amp;body={{ full_page_url|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share by Email" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-envelope" />
+            </svg>
+        </a>
+    </div>
+{% endwith %}
+{% endspaceless %}

--- a/sites/funcampus/src/backend/templates/social-networks/course-badges.html
+++ b/sites/funcampus/src/backend/templates/social-networks/course-badges.html
@@ -1,0 +1,48 @@
+{% load i18n static %}{% spaceless %}
+{% with full_page_url=SITE.web_url|add:page_url %}
+    {% blocktrans asvar shared_subject %}Follow a course online with FUN Campus{% endblocktrans %}
+    {% blocktrans with title=page_title|safe url=full_page_url asvar shared_sentence %}I just enrolled to the course "{{ title }}" with FUN Campus: {{ url }}{% endblocktrans %}
+    <div class="social-network-badges">
+        <a
+            href="https://www.facebook.com/share.php?u={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Facebook" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-facebook" />
+            </svg>
+        </a>
+        <a
+            href="https://twitter.com/intent/tweet?text={{ shared_sentence|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Twitter" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-twitter" />
+            </svg>
+        </a>
+        <a
+            href="https://www.linkedin.com/sharing/share-offsite/?url={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Linkedin" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-linkedin" />
+            </svg>
+        </a>
+        <a
+            href="mailto:?subject={{ shared_subject|urlencode }}&amp;body={{ shared_sentence|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share by Email" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-envelope" />
+            </svg>
+        </a>
+  </div>
+{% endwith %}
+{% endspaceless %}

--- a/sites/funcampus/src/backend/templates/social-networks/footer-badges.html
+++ b/sites/funcampus/src/backend/templates/social-networks/footer-badges.html
@@ -1,0 +1,34 @@
+{% load i18n static %}{% spaceless %}
+    <a
+        href="https://www.facebook.com/france.universite.numerique/"
+        class="body-footer__badge"
+        target="_blank"
+    >
+        <svg role="img">
+            <title>{% trans "Facebook" %}</title>
+            <use xlink:href="#icon-facebook" />
+        </svg>
+    </a>
+    <a
+        href="https://twitter.com/FunMooc"
+        class="body-footer__badge"
+        target="_blank"
+        title="{% trans "Twitter page" %}"
+    >
+        <svg role="img">
+            <title>{% trans "Twitter" %}</title>
+            <use xlink:href="#icon-twitter" />
+        </svg>
+    </a>
+   <a
+        href="https://www.linkedin.com/school/franceuniversitenumerique/"
+        class="body-footer__badge"
+        target="_blank"
+        title="{% trans "Linkedin" %}"
+    >
+        <svg role="img">
+            <title>{% trans "Linkedin" %}</title>
+            <use xlink:href="#icon-linkedin" />
+        </svg>
+    </a>
+{% endspaceless %}

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add i18n messages compilation in the DockerFile so translations are ready
+
 ## [0.5.0] - 2020-08-20
 
 ### Changed

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Customize filters visible on the search page
 - Customize social networks links
 
 ### Fixed

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Customize social networks links
+
 ### Fixed
 
 - Add i18n messages compilation in the DockerFile so translations are ready

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -322,6 +322,47 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         ],
     }
 
+    # Search
+    RICHIE_FILTERS_CONFIGURATION = [
+        (
+            "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
+            {
+                "human_name": _("Subjects"),
+                "is_autocompletable": True,
+                "is_searchable": True,
+                "min_doc_count": 0,
+                "name": "subjects",
+                "position": 1,
+                "reverse_id": "subjects",
+                "term": "categories",
+            },
+        ),
+        (
+            "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
+            {
+                "human_name": _("Organizations"),
+                "is_autocompletable": True,
+                "is_searchable": True,
+                "min_doc_count": 0,
+                "name": "organizations",
+                "position": 2,
+                "reverse_id": "organizations",
+            },
+        ),
+        (
+            "richie.apps.search.filter_definitions.IndexableFilterDefinition",
+            {
+                "human_name": _("Persons"),
+                "is_autocompletable": True,
+                "is_searchable": True,
+                "min_doc_count": 0,
+                "name": "persons",
+                "position": 3,
+                "reverse_id": "persons",
+            },
+        ),
+    ]
+
     # - Django Parler
     PARLER_LANGUAGES = CMS_LANGUAGES
 

--- a/sites/funcorporate/src/backend/locale/en/LC_MESSAGES/django.po
+++ b/sites/funcorporate/src/backend/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,98 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-25 18:58+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: base/admin.py:34
+msgid "Unsorted uploads are not allowed."
+msgstr ""
+
+#: funcorporate/settings.py:295 funcorporate/settings.py:310
+msgid "English"
+msgstr ""
+
+#: funcorporate/settings.py:295 funcorporate/settings.py:318
+msgid "French"
+msgstr ""
+
+#: funcorporate/settings.py:330
+msgid "Subjects"
+msgstr ""
+
+#: funcorporate/settings.py:343
+msgid "Organizations"
+msgstr ""
+
+#: funcorporate/settings.py:355
+msgid "Persons"
+msgstr "Teachers"
+
+#: templates/social-networks/blogpost-badges.html:3
+#, python-format
+msgid "FUN Corporate news: %(title)s"
+msgstr ""
+
+#: templates/social-networks/blogpost-badges.html:4
+#, python-format
+msgid "FUN Corporate news: %(title)s %(url)s"
+msgstr ""
+
+#: templates/social-networks/blogpost-badges.html:10
+#: templates/social-networks/course-badges.html:10
+msgid "Share on Facebook"
+msgstr ""
+
+#: templates/social-networks/blogpost-badges.html:20
+#: templates/social-networks/course-badges.html:20
+msgid "Share on Twitter"
+msgstr ""
+
+#: templates/social-networks/blogpost-badges.html:30
+#: templates/social-networks/course-badges.html:30
+msgid "Share on Linkedin"
+msgstr ""
+
+#: templates/social-networks/blogpost-badges.html:40
+#: templates/social-networks/course-badges.html:40
+msgid "Share by Email"
+msgstr ""
+
+#: templates/social-networks/course-badges.html:3
+msgid "Follow a course online with FUN Corporate"
+msgstr ""
+
+#: templates/social-networks/course-badges.html:4
+#, python-format
+msgid "I just enrolled to the course \"%(title)s\" with FUN Corporate: %(url)s"
+msgstr ""
+
+#: templates/social-networks/footer-badges.html:8
+msgid "Facebook"
+msgstr ""
+
+#: templates/social-networks/footer-badges.html:16
+msgid "Twitter page"
+msgstr ""
+
+#: templates/social-networks/footer-badges.html:19
+msgid "Twitter"
+msgstr ""
+
+#: templates/social-networks/footer-badges.html:27
+#: templates/social-networks/footer-badges.html:30
+msgid "Linkedin"
+msgstr ""

--- a/sites/funcorporate/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funcorporate/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,99 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-25 18:58+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: base/admin.py:34
+msgid "Unsorted uploads are not allowed."
+msgstr "Les téléchargements non classés sont interdits"
+
+#: funcorporate/settings.py:295 funcorporate/settings.py:310
+msgid "English"
+msgstr "Anglais"
+
+#: funcorporate/settings.py:295 funcorporate/settings.py:318
+msgid "French"
+msgstr "Français"
+
+#: funcorporate/settings.py:330
+msgid "Subjects"
+msgstr "Thématiques"
+
+#: funcorporate/settings.py:343
+msgid "Organizations"
+msgstr "Établissements"
+
+#: funcorporate/settings.py:355
+msgid "Persons"
+msgstr "Professeurs"
+
+#: templates/social-networks/blogpost-badges.html:3
+#, python-format
+msgid "FUN Corporate news: %(title)s"
+msgstr "Actualité FUN Corporate: %(title)s"
+
+#: templates/social-networks/blogpost-badges.html:4
+#, python-format
+msgid "FUN Corporate news: %(title)s %(url)s"
+msgstr "Actualité FUN Corporate: %(title)s %(url)s"
+
+#: templates/social-networks/blogpost-badges.html:10
+#: templates/social-networks/course-badges.html:10
+msgid "Share on Facebook"
+msgstr "Partager sur Facebook"
+
+#: templates/social-networks/blogpost-badges.html:20
+#: templates/social-networks/course-badges.html:20
+msgid "Share on Twitter"
+msgstr "Partager sur Twitter"
+
+#: templates/social-networks/blogpost-badges.html:30
+#: templates/social-networks/course-badges.html:30
+msgid "Share on Linkedin"
+msgstr "Partager sur Linkedin"
+
+#: templates/social-networks/blogpost-badges.html:40
+#: templates/social-networks/course-badges.html:40
+msgid "Share by Email"
+msgstr "Partager par Email"
+
+#: templates/social-networks/course-badges.html:3
+msgid "Follow a course online with FUN Corporate"
+msgstr "Suivre un cours en ligne avec FUN Corporate"
+
+#: templates/social-networks/course-badges.html:4
+#, python-format
+msgid "I just enrolled to the course \"%(title)s\" with FUN Corporate: %(url)s"
+msgstr ""
+"Je viens de m'inscrire au cours \"%(title)s\" sur FUN Corporate: %(url)s"
+
+#: templates/social-networks/footer-badges.html:8
+msgid "Facebook"
+msgstr "Facebook"
+
+#: templates/social-networks/footer-badges.html:16
+msgid "Twitter page"
+msgstr "Page Twitter"
+
+#: templates/social-networks/footer-badges.html:19
+msgid "Twitter"
+msgstr "Twitter"
+
+#: templates/social-networks/footer-badges.html:27
+#: templates/social-networks/footer-badges.html:30
+msgid "Linkedin"
+msgstr "Linkedin"

--- a/sites/funcorporate/src/backend/templates/social-networks/blogpost-badges.html
+++ b/sites/funcorporate/src/backend/templates/social-networks/blogpost-badges.html
@@ -1,0 +1,48 @@
+{% load i18n static %}{% spaceless %}
+{% with full_page_url=SITE.web_url|add:page_url %}
+    {% blocktrans with title=page_title asvar mailto_subject %}FUN Corporate news: {{ title }}{% endblocktrans %}
+    {% blocktrans with title=page_title|safe url=full_page_url asvar shared_sentence %}FUN Corporate news: {{ title }} {{ url }}{% endblocktrans %}
+    <div class="social-network-badges">
+        <a
+            href="https://www.facebook.com/share.php?u={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Facebook" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-facebook" />
+            </svg>
+        </a>
+        <a
+            href="https://twitter.com/intent/tweet?text={{ shared_sentence|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Twitter" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-twitter" />
+            </svg>
+        </a>
+        <a
+            href="https://www.linkedin.com/sharing/share-offsite/?url={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Linkedin" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-linkedin" />
+            </svg>
+        </a>
+        <a
+            href="mailto:?subject={{ mailto_subject|urlencode }}&amp;body={{ full_page_url|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share by Email" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-envelope" />
+            </svg>
+        </a>
+    </div>
+{% endwith %}
+{% endspaceless %}

--- a/sites/funcorporate/src/backend/templates/social-networks/course-badges.html
+++ b/sites/funcorporate/src/backend/templates/social-networks/course-badges.html
@@ -1,0 +1,48 @@
+{% load i18n static %}{% spaceless %}
+{% with full_page_url=SITE.web_url|add:page_url %}
+    {% blocktrans asvar shared_subject %}Follow a course online with FUN Corporate{% endblocktrans %}
+    {% blocktrans with title=page_title|safe url=full_page_url asvar shared_sentence %}I just enrolled to the course "{{ title }}" with FUN Corporate: {{ url }}{% endblocktrans %}
+    <div class="social-network-badges">
+        <a
+            href="https://www.facebook.com/share.php?u={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Facebook" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-facebook" />
+            </svg>
+        </a>
+        <a
+            href="https://twitter.com/intent/tweet?text={{ shared_sentence|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Twitter" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-twitter" />
+            </svg>
+        </a>
+        <a
+            href="https://www.linkedin.com/sharing/share-offsite/?url={{ full_page_url }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share on Linkedin" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-linkedin" />
+            </svg>
+        </a>
+        <a
+            href="mailto:?subject={{ shared_subject|urlencode }}&amp;body={{ shared_sentence|urlencode }}"
+            class="social-network-badges__item"
+            target="_blank"
+            title="{% trans "Share by Email" %}"
+        >
+            <svg role="img">
+                <use xlink:href="#icon-envelope" />
+            </svg>
+        </a>
+  </div>
+{% endwith %}
+{% endspaceless %}

--- a/sites/funcorporate/src/backend/templates/social-networks/footer-badges.html
+++ b/sites/funcorporate/src/backend/templates/social-networks/footer-badges.html
@@ -1,0 +1,34 @@
+{% load i18n static %}{% spaceless %}
+    <a
+        href="https://www.facebook.com/france.universite.numerique/"
+        class="body-footer__badge"
+        target="_blank"
+    >
+        <svg role="img">
+            <title>{% trans "Facebook" %}</title>
+            <use xlink:href="#icon-facebook" />
+        </svg>
+    </a>
+    <a
+        href="https://twitter.com/FunMooc"
+        class="body-footer__badge"
+        target="_blank"
+        title="{% trans "Twitter page" %}"
+    >
+        <svg role="img">
+            <title>{% trans "Twitter" %}</title>
+            <use xlink:href="#icon-twitter" />
+        </svg>
+    </a>
+   <a
+        href="https://www.linkedin.com/school/franceuniversitenumerique/"
+        class="body-footer__badge"
+        target="_blank"
+        title="{% trans "Linkedin" %}"
+    >
+        <svg role="img">
+            <title>{% trans "Linkedin" %}</title>
+            <use xlink:href="#icon-linkedin" />
+        </svg>
+    </a>
+{% endspaceless %}

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add i18n messages compilation in the DockerFile so translations are ready
+
 ## [0.13.0] - 2020-08-20
 
 ### Changed


### PR DESCRIPTION
### Purpose

We want to customize social networks links and search filters for funcampus and funcorporate.

### Proposal

For the moment, we use the same social network links as for funmooc.

On fun-campus, show only search filters on 4 dimensions of categories.
On fun-corporate, remove search filters related to course sessions that are not present on this site.

Note: I also added i18n compilation in the DockerFile so the translations are available out-of-the-box.
