### PR TITLE
set SOCIAL_AUTH_REDIRECT_IS_HTTPS to true in settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,11 +334,66 @@ workflows:
                 name: no-change-cnfpt
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
             - no-change:
@@ -348,66 +403,11 @@ workflows:
                 name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - no-change:

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- set SOCIAL_AUTH_REDIRECT_IS_HTTPS to True in settings
+
 ## [2.0.0-beta.14.2] - 2020-09-04
 
 ### Fixed 

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-beta.14.3] - 2020-09-08
+
 ### Fixed
 
 - set SOCIAL_AUTH_REDIRECT_IS_HTTPS to True in settings
@@ -61,7 +63,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 First demo image for richie to 2.0.0-beta.7
 
-[unreleased]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.2...HEAD
+[unreleased]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.3...HEAD
+[2.0.0-beta.14.3]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.2...demo-2.0.0-beta.14.3
 [2.0.0-beta.14.2]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.1...demo-2.0.0-beta.14.2
 [2.0.0-beta.14.1]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14...demo-2.0.0-beta.14.1
 [2.0.0-beta.14]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.11...demo-2.0.0-beta.14

--- a/sites/demo/src/backend/demo/__init__.py
+++ b/sites/demo/src/backend/demo/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.14.2"
+__version__ = "2.0.0-beta.14.3"

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -563,6 +563,10 @@ class Production(Base):
     # CDN domain for static/media urls. It is passed to the frontend to load built chunks
     CDN_DOMAIN = values.Value()
 
+    # Social auth
+    # Force https schema in redirect uri
+    SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
+
     @property
     def TEXT_CKEDITOR_BASE_PATH(self):
         """Configure CKEditor with an absolute url as base path to point to CloudFront."""

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie",
-  "version": "2.0.0-beta.14.2",
+  "version": "2.0.0-beta.14.3",
   "description": "Richie demo site on https://demo.richie.education",
   "scripts": {
     "prettier": "prettier '**/*.+(css|scss)'",


### PR DESCRIPTION
### Purpose

Richie is behind a proxy and the redirect uri computed has a wrong
schema, http instead of https. To force https we must set the setting
SOCIAL_AUTH_REDIRECT_IS_HTTPS to True.

### Proposal

- [x] set SOCIAL_AUTH_REDIRECT_IS_HTTPS to true in settings
- [x] prepare release  2.0.0-beta.14.3