### PR TITLE
add missing courses url pattern 

### DIFF
--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Add missing courses API url pattern
 - The banner search title should be white
 
 ## [0.5.0] - 2020-08-31

--- a/sites/cnfpt/src/backend/cnfpt/urls.py
+++ b/sites/cnfpt/src/backend/cnfpt/urls.py
@@ -12,6 +12,7 @@ from django.views.static import serve
 
 from cms.sitemaps import CMSSitemap
 from richie.apps.core.urls import urlpatterns as core_urlpatterns
+from richie.apps.courses.urls import urlpatterns as courses_urlpatterns
 from richie.apps.search.urls import urlpatterns as search_urlpatterns
 
 # For now, we use URLPathVersioning to be consistent with fonzie. Fonzie uses it
@@ -25,7 +26,7 @@ urlpatterns = [
     url(r"^sitemap\.xml$", sitemap, {"sitemaps": {"cmspages": CMSSitemap}}),
     url(
         r"^api/{}/".format(API_PREFIX),
-        include([*core_urlpatterns, *search_urlpatterns]),
+        include([*core_urlpatterns, *courses_urlpatterns, *search_urlpatterns]),
     ),
     url(r"^oauth/", include("social_django.urls", namespace="social")),
     url(r"^", include("filer.server.urls")),

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing courses API url pattern
+
 ### Changed
 
 - Bump lodash from 4.17.14 to 4.17.20

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-beta.14.4] - 2020-09-08
+
 ### Fixed
 
 - Add missing courses API url pattern
@@ -71,7 +73,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 First demo image for richie to 2.0.0-beta.7
 
-[unreleased]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.3...HEAD
+[unreleased]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.4...HEAD
+[2.0.0-beta.14.4]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.3...demo-2.0.0-beta.14.4
 [2.0.0-beta.14.3]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.2...demo-2.0.0-beta.14.3
 [2.0.0-beta.14.2]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14.1...demo-2.0.0-beta.14.2
 [2.0.0-beta.14.1]: https://github.com/openfun/richie-site-factory/compare/demo-2.0.0-beta.14...demo-2.0.0-beta.14.1

--- a/sites/demo/src/backend/demo/__init__.py
+++ b/sites/demo/src/backend/demo/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.14.3"
+__version__ = "2.0.0-beta.14.4"

--- a/sites/demo/src/backend/demo/urls.py
+++ b/sites/demo/src/backend/demo/urls.py
@@ -12,6 +12,7 @@ from django.views.static import serve
 
 from cms.sitemaps import CMSSitemap
 from richie.apps.core.urls import urlpatterns as core_urlpatterns
+from richie.apps.courses.urls import urlpatterns as courses_urlpatterns
 from richie.apps.search.urls import urlpatterns as search_urlpatterns
 
 # For now, we use URLPathVersioning to be consistent with fonzie. Fonzie uses it
@@ -25,7 +26,7 @@ urlpatterns = [
     url(r"^sitemap\.xml$", sitemap, {"sitemaps": {"cmspages": CMSSitemap}}),
     url(
         r"^api/{}/".format(API_PREFIX),
-        include([*core_urlpatterns, *search_urlpatterns]),
+        include([*core_urlpatterns, *courses_urlpatterns, *search_urlpatterns]),
     ),
     url(r"^oauth/", include("social_django.urls", namespace="social")),
     url(r"^", include("filer.server.urls")),

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie",
-  "version": "2.0.0-beta.14.3",
+  "version": "2.0.0-beta.14.4",
   "description": "Richie demo site on https://demo.richie.education",
   "scripts": {
     "prettier": "prettier '**/*.+(css|scss)'",


### PR DESCRIPTION
### Purpose

in urls module we missed to add courses url patterns leading to 404
error once deployed.

### Proposal

- [x] (cnfpt) add missing courses url pattern 
- [x] (demo) add missing courses url pattern 
- [x] (demo) bump demo to 2.0.0-beta.14.4 