### PR TITLE
Feat/subheader cta legend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,11 +341,66 @@ workflows:
                 name: no-change-demo
     funcampus:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcampus
+                        only: /funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
     funcorporate:
         jobs:
             - check-changelog:

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Override `course_detail` template to add a message above subheader CTA.
+
 ### Changed
 
 - Customize filters visible on the search page

--- a/sites/funcampus/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funcampus/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-25 18:48+0200\n"
+"POT-Creation-Date: 2020-09-14 09:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,10 @@ msgstr "Anglais"
 #: funcampus/settings.py:355 funcampus/settings.py:378
 msgid "French"
 msgstr "Français"
+
+#: templates/courses/cms/course_detail.html:5
+msgid "Would you like to use this course with your students?"
+msgstr "Vous souhaitez utiliser ce cours avec vos étudiants&nbsp;?"
 
 #: templates/richie/base.html:19
 msgid "Courses that enrich academic education"

--- a/sites/funcampus/src/backend/templates/courses/cms/course_detail.html
+++ b/sites/funcampus/src/backend/templates/courses/cms/course_detail.html
@@ -1,4 +1,10 @@
 {% extends "courses/cms/course_detail.html" %}
+{% load i18n %}
+
+{% block contact %}
+    <p class="subheader__cta-legend">{% trans "Would you like to use this course with your students?" %}</p>
+    {{ block.super }}
+{% endblock contact %}
 
 {% comment %}Disable content parts related to course runs{% endcomment %}
 {% block snapshot %}{% endblock snapshot %}

--- a/sites/funcampus/src/frontend/scss/_main.scss
+++ b/sites/funcampus/src/frontend/scss/_main.scss
@@ -81,7 +81,7 @@
 
 // Page component styles
 @import 'richie-education/scss/components/header';
-@import 'richie-education/scss/components/subheader';
+@import './components/subheader';
 @import 'richie-education/scss/components/footer';
 @import 'richie-education/scss/components/styleguide';
 @import 'richie-education/scss/components/content';

--- a/sites/funcampus/src/frontend/scss/components/_subheader.scss
+++ b/sites/funcampus/src/frontend/scss/components/_subheader.scss
@@ -1,0 +1,8 @@
+@import 'richie-education/scss/components/subheader.scss';
+
+.subheader {
+    &__cta-legend {
+        margin-top: 1rem;
+        margin-bottom: 0;
+    }
+}

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+
+- Override `course_detail` template to add a message above subheader CTA.
 - Use the FunCorporate Zendesk link on "Contact Us" CTA in header.
 
 ### Changed

--- a/sites/funcorporate/src/backend/locale/en/LC_MESSAGES/django.po
+++ b/sites/funcorporate/src/backend/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-04 17:40+0200\n"
+"POT-Creation-Date: 2020-09-14 09:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,6 +40,10 @@ msgstr ""
 #: funcorporate/settings.py:355
 msgid "Persons"
 msgstr "Teachers"
+
+#: templates/courses/cms/course_detail.html:5
+msgid "Would you like to offer this training to your employees?"
+msgstr ""
 
 #: templates/richie/base.html:18
 msgid "Help"

--- a/sites/funcorporate/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funcorporate/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-04 17:40+0200\n"
+"POT-Creation-Date: 2020-09-14 09:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,6 +40,10 @@ msgstr "Établissements"
 #: funcorporate/settings.py:355
 msgid "Persons"
 msgstr "Professeurs"
+
+#: templates/courses/cms/course_detail.html:5
+msgid "Would you like to offer this training to your employees?"
+msgstr "Vous souhaitez proposer cette formation à vos salariés&nbsp;?"
 
 #: templates/richie/base.html:18
 msgid "Help"

--- a/sites/funcorporate/src/backend/templates/courses/cms/course_detail.html
+++ b/sites/funcorporate/src/backend/templates/courses/cms/course_detail.html
@@ -1,4 +1,10 @@
 {% extends "courses/cms/course_detail.html" %}
+{% load i18n %}
+
+{% block contact %}
+    <p class="subheader__cta-legend">{% trans "Would you like to offer this training to your employees?" %}</p>
+{{ block.super }}
+{% endblock contact %}
 
 {% comment %}Disable content parts related to course runs{% endcomment %}
 {% block snapshot %}{% endblock snapshot %}

--- a/sites/funcorporate/src/frontend/scss/components/_subheader.scss
+++ b/sites/funcorporate/src/frontend/scss/components/_subheader.scss
@@ -9,4 +9,9 @@
       );
     }
   }
+
+  &__cta-legend {
+    margin-top: 1rem;
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
## Purpose
On funcampus & funcorporate platforms, we would like to display a custom message on the course detail page above the CTA in the subheader.

## Proposal
- [x] Override funcampus & funcorporate `course_detail` templates to add a message above subheader__cta
<img width="1000" alt="funcorporate result" src="https://user-images.githubusercontent.com/9265241/92940242-2ba44100-f44f-11ea-8b2a-76c130e62ba4.png">
<img width="1000" alt="funcampus result" src="https://user-images.githubusercontent.com/9265241/92940233-2941e700-f44f-11ea-9590-b2983d91ae70.png">
