### PR TITLE
✨(demo) force user.is_superuser on login when they have is_staff True

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,135 +327,80 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
+            - no-change:
+                filters:
+                    tags:
+                        only: /.*/
+                name: no-change-cnfpt
+    demo:
+        jobs:
             - check-changelog:
                 filters:
                     branches:
                         ignore: master
-                name: check-changelog-cnfpt
-                site: cnfpt
+                name: check-changelog-demo
+                site: demo
             - lint-changelog:
                 filters:
                     branches:
                         ignore: master
                     tags:
-                        only: /cnfpt-.*/
-                name: lint-changelog--cnfpt
-                site: cnfpt
+                        only: /demo-.*/
+                name: lint-changelog--demo
+                site: demo
             - build-front-production:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-front-production-cnfpt
-                site: cnfpt
+                        only: /demo-.*/
+                name: build-front-production-demo
+                site: demo
             - lint-front:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: lint-front-cnfpt
+                        only: /demo-.*/
+                name: lint-front-demo
                 requires:
-                    - build-front-production-cnfpt
-                site: cnfpt
+                    - build-front-production-demo
+                site: demo
             - build-back:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-back-cnfpt
-                site: cnfpt
+                        only: /demo-.*/
+                name: build-back-demo
+                site: demo
             - lint-back:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: lint-back-cnfpt
+                        only: /demo-.*/
+                name: lint-back-demo
                 requires:
-                    - build-back-cnfpt
-                site: cnfpt
+                    - build-back-demo
+                site: demo
             - test-back:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: test-back-cnfpt
+                        only: /demo-.*/
+                name: test-back-demo
                 requires:
-                    - build-back-cnfpt
-                site: cnfpt
+                    - build-back-demo
+                site: demo
             - hub:
                 filters:
                     tags:
-                        only: /^cnfpt-.*/
-                image_name: cnfpt
-                name: hub-cnfpt
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
                 requires:
-                    - lint-front-cnfpt
-                    - lint-back-cnfpt
-                site: cnfpt
-    demo:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
+    funcampus:
         jobs:
             - no-change:
                 filters:
                     tags:
                         only: /.*/
-                name: no-change-demo
-    funcampus:
-        jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                name: no-change-funcampus
     funcorporate:
         jobs:
             - no-change:

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add step in the social auth connection pipeline to force user
+  having is_staff set to true to also have is_superuser set to true.
+
 ## [2.0.0-beta.14.5] - 2020-09-08
 
 ### Fixed

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -198,6 +198,37 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     SOCIAL_AUTH_EDX_OAUTH2_ENDPOINT = values.Value()
     SOCIAL_AUTH_POSTGRES_JSONFIELD = False
 
+    SOCIAL_AUTH_PIPELINE = (
+        # Get the information we can about the user and return it in a simple
+        # format to create the user instance later. In some cases the details are
+        # already part of the auth response from the provider, but sometimes this
+        # could hit a provider API.
+        "social_core.pipeline.social_auth.social_details",
+        # Get the social uid from whichever service we're authing thru. The uid is
+        # the unique identifier of the given user in the provider.
+        "social_core.pipeline.social_auth.social_uid",
+        # Verifies that the current auth process is valid within the current
+        # project, this is where emails and domains whitelists are applied (if
+        # defined).
+        "social_core.pipeline.social_auth.auth_allowed",
+        # Checks if the current social-account is already associated in the site.
+        "social_core.pipeline.social_auth.social_user",
+        # Make up a username for this person, appends a random string at the end if
+        # there's any collision.
+        "social_core.pipeline.user.get_username",
+        # Create a user account if we haven't found one yet.
+        "social_core.pipeline.user.create_user",
+        # User exists, update it to superuser if needed
+        "demo.social.pipeline.user.set_super_user",
+        # Create the record that associates the social account with the user.
+        "social_core.pipeline.social_auth.associate_user",
+        # Populate the extra_data field in the social record with the values
+        # specified by settings (and the default ones like access_token, etc).
+        "social_core.pipeline.social_auth.load_extra_data",
+        # Update the user record with any changed info from the auth service.
+        "social_core.pipeline.user.user_details",
+    )
+
     # LMS
     LMS_BACKENDS = [
         {
@@ -233,8 +264,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "family_name": "last_name",
         "locale": "language",
         "user_id": "user_id",
-        "is_staff": "is_staff",
-        "is_superuser": "is_superuser",
+        "administrator": "is_staff",
     }
 
     # Templates

--- a/sites/demo/src/backend/demo/social/pipeline/user.py
+++ b/sites/demo/src/backend/demo/social/pipeline/user.py
@@ -1,0 +1,10 @@
+"""Pipeline used only for the demo to add all permissions to a staff user."""
+
+
+def set_super_user(strategy, details, backend, user=None, *args, **kwargs):
+    """
+    set user.is_superuser to True if there is_staff is set in the details and the user exists.
+    """
+    if details.get("is_staff", False) and user:
+        user.is_superuser = True
+        strategy.storage.user.changed(user)


### PR DESCRIPTION
### Purpose

OpenEdx hawthorn doesn't send in the oauth response if the user is a
superuser, only if he is a staff member. For the demo we decided to set
a user as superuser if he is staff. For this we added a function in the
authentication pipeline executed once we are sure a user exists and
check if he is a staff member. If it's the case then we set the user as
a superuser and we save it.

### Proposal

- [x] force user.is_superuser on login when they have is_staff True