### PR TITLE
🏗(funcampus) move cms site to www.fun-campus.fr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,66 +341,11 @@ workflows:
                 name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
             - no-change:

--- a/sites/funcampus/aws/config.tfvars
+++ b/sites/funcampus/aws/config.tfvars
@@ -1,7 +1,7 @@
 site = "funcampus"
 
 app_domain = {
-  production = "new.fun-campus.fr"
+  production = "www.fun-campus.fr"
   preprod = "preprod.funedu.oc.openfun.fr"
   staging = "staging.funedu.oc.openfun.fr"
 }


### PR DESCRIPTION
### Purpose

The LMS is now hosted on https://lms.fun-campus.fr and richie on the main domain https://www.fun-campus.fr.

### Proposal

Update AWS CloudFront CDN to point to the new host.