### PR TITLE
✨(project) add script to automate tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,66 +348,11 @@ workflows:
                 name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - no-change:

--- a/bin/tag
+++ b/bin/tag
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+function usage(){
+    echo -e "Usage: ${0} [OPTIONS]
+
+Tag all untagged release commits (starting with the 🔖 gitmoji) and
+push the tags to github so the image is built and pushed to DockerHub.
+
+OPTIONS:
+  -h, --help       print this message
+  -c, --commit     dry run if this option is not set
+"
+}
+
+declare -i should_commit=0
+declare regex="🔖\(.*\).*version [0-9\.]*"
+
+# Parse options
+for i in "$@"
+do
+    case $i in
+        -h|--help|help)
+            usage "${0}"
+            exit 0
+            ;;
+        -c|--commit)
+            should_commit=1
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+git fetch origin
+
+# Loop over new release commits that were not tagged yet
+for commit_hash in $(git log --grep="${regex}" --since=2020-10-07 --pretty=format:"%h %d" | grep -v "tag:" | awk '{print $1}')
+do
+    version=$(git show --format="%s" -s "${commit_hash}" | sed -E "s/.*version ([0-9\.]*).*/\1/")
+    site=$(git show --format="%s" -s "${commit_hash}" | sed -E "s/🔖\((.*)\).*/\1/")
+    action=$([[ "${should_commit}" == 1 ]] && echo "Tagging" || echo "Would tag")
+
+    echo -e "${COLOR_INFO}${action} ${commit_hash} with ${site}-${version}${COLOR_RESET}"
+    if [[ "${should_commit}" == 1 ]]; then
+        git tag "${site}-${version}" "${commit_hash}"
+        git push origin --tags
+    fi
+done


### PR DESCRIPTION
## Purpose

Once release commits have landed to master, we need to tag them before pushing the tags to github. This is repetitive and painful
so we should automate it.

## Proposal

Add a `tag` script that:

- looks for commits starting with the 🔖 gitmoji, 
- extracts the site and version from the commit subject
- tags the commit with the corresponding tag of the form {site}-{version}
