### PR TITLE
✨(funcampus/frontend) display course duration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,73 +347,73 @@ workflows:
                 name: no-change-demo
     funcampus:
         jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-funcampus
-    funcorporate:
-        jobs:
             - check-changelog:
                 filters:
                     branches:
                         ignore: master
-                name: check-changelog-funcorporate
-                site: funcorporate
+                name: check-changelog-funcampus
+                site: funcampus
             - lint-changelog:
                 filters:
                     branches:
                         ignore: master
                     tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
+                        only: /funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
             - build-front-production:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
+                        only: /funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
             - lint-front:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
+                        only: /funcampus-.*/
+                name: lint-front-funcampus
                 requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
+                    - build-front-production-funcampus
+                site: funcampus
             - build-back:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
+                        only: /funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
             - lint-back:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
+                        only: /funcampus-.*/
+                name: lint-back-funcampus
                 requires:
-                    - build-back-funcorporate
-                site: funcorporate
+                    - build-back-funcampus
+                site: funcampus
             - test-back:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
+                        only: /funcampus-.*/
+                name: test-back-funcampus
                 requires:
-                    - build-back-funcorporate
-                site: funcorporate
+                    - build-back-funcampus
+                site: funcampus
             - hub:
                 filters:
                     tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
                 requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
+    funcorporate:
+        jobs:
+            - no-change:
+                filters:
+                    tags:
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - no-change:

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Display course duration in course glimpse footer
+
 ## [0.5.0] - 2020-10-08
 
 ### Added
@@ -86,4 +90,5 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 [0.3.1]: https://github.com/openfun/richie-site-factory/compare/funcampus-0.3.0...funcampus-0.3.1
 [0.3.0]: https://github.com/openfun/richie-site-factory/compare/funcampus-0.2.0...funcampus-0.3.0
 [0.2.0]: https://github.com/openfun/richie-site-factory/compare/funcampus-0.1.0...funcampus-0.2.0
+
 [0.1.0]: https://github.com/openfun/richie-site-factory/compare/ 185f9deff5c4dd79e21f4f42c2acd1d17c73c293...funcampus-0.1.0

--- a/sites/funcampus/src/backend/templates/courses/cms/fragment_course_glimpse.html
+++ b/sites/funcampus/src/backend/templates/courses/cms/fragment_course_glimpse.html
@@ -1,0 +1,11 @@
+{% extends "courses/cms/fragment_course_glimpse.html" %}
+{% block course_glimpse_footer %}
+<div class="course-{{ course_variant }}-footer">
+  <div class="course-{{ course_variant }}-footer__date">
+    <svg role="img" aria-hidden="true" class="icon">
+      <use xlink:href="#icon-clock" />
+    </svg>
+    {{course.get_duration_display|default:"NA"}}
+  </div>
+</div>
+{% endblock course_glimpse_footer %}

--- a/sites/funcampus/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
+++ b/sites/funcampus/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { CommonDataProps } from 'richie-education/js/types/commonDataProps';
+import { Course } from 'richie-education/js/types/Course';
+
+/**
+ * <CourseGlimpseFooter />.
+ * This is spun off from <CourseGlimpse /> to allow easier override through webpack.
+ */
+export const CourseGlimpseFooter: React.FC<{ course: Course } & CommonDataProps> = ({ course }) => (
+  <div className="course-glimpse-footer">
+    <div className="course-glimpse-footer__date">
+      <svg aria-hidden={true} role="img" className="icon">
+        <use xlinkHref="#icon-clock" />
+      </svg>
+      {course.duration}
+    </div>
+  </div>
+);

--- a/sites/funcampus/src/frontend/overrides.json
+++ b/sites/funcampus/src/frontend/overrides.json
@@ -1,3 +1,5 @@
 {
-  "overrides": {}
+  "overrides": {
+    "CourseGlimpse/CourseGlimpseFooter.tsx": "../../../../../js/components/CourseGlimpse/CourseGlimpseFooter.tsx"
+  }
 }

--- a/sites/funcampus/src/frontend/package.json
+++ b/sites/funcampus/src/frontend/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/openfun/richie-site-factory#readme",
   "dependencies": {
+    "react": "16.13.1",
     "richie-education": "2.0.0-beta.15"
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose
This is no sens to display course state in course glimpse footer on FUN Corporate.

⚠️ This PR depends to [this other one](https://github.com/openfun/richie-site-factory/pull/139) #139

## Proposal

- [x] Replace course state information by its duration