### PR TITLE
🔧(funcorporate) customize max number of plugins in course description

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,73 +347,73 @@ workflows:
                 name: no-change-demo
     funcampus:
         jobs:
+            - no-change:
+                filters:
+                    tags:
+                        only: /.*/
+                name: no-change-funcampus
+    funcorporate:
+        jobs:
             - check-changelog:
                 filters:
                     branches:
                         ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
+                name: check-changelog-funcorporate
+                site: funcorporate
             - lint-changelog:
                 filters:
                     branches:
                         ignore: master
                     tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
+                        only: /funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
             - build-front-production:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
+                        only: /funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
             - lint-front:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
+                        only: /funcorporate-.*/
+                name: lint-front-funcorporate
                 requires:
-                    - build-front-production-funcampus
-                site: funcampus
+                    - build-front-production-funcorporate
+                site: funcorporate
             - build-back:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
+                        only: /funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
             - lint-back:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
+                        only: /funcorporate-.*/
+                name: lint-back-funcorporate
                 requires:
-                    - build-back-funcampus
-                site: funcampus
+                    - build-back-funcorporate
+                site: funcorporate
             - test-back:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
+                        only: /funcorporate-.*/
+                name: test-back-funcorporate
                 requires:
-                    - build-back-funcampus
-                site: funcampus
+                    - build-back-funcorporate
+                site: funcorporate
             - hub:
                 filters:
                     tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
                 requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
-    funcorporate:
-        jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
             - no-change:

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Allow several plugins in course description to relax limit on number of char
 - Open contact form in a new tab
 - Display course duration in course glimpse footer
 

--- a/sites/funcorporate/src/backend/base/tests/test_utils.py
+++ b/sites/funcorporate/src/backend/base/tests/test_utils.py
@@ -1,0 +1,17 @@
+"""Test base utils."""
+
+from django.test import TestCase
+
+from ..utils import merge_dict
+
+
+class UtilsTestCase(TestCase):
+    """Validate that utils in the base app work as expected."""
+
+    def test_utils_merge_dict(self):
+        """Update a deep nested dictionary with another deep nested dictionary."""
+        d1 = {"k1": {"k11": {"a": 0, "b": 1}}}
+        d2 = {"k1": {"k11": {"b": 10}, "k12": {"a": 3}}}
+        self.assertEqual(
+            merge_dict(d1, d2), {"k1": {"k11": {"a": 0, "b": 10}, "k12": {"a": 3}}}
+        )

--- a/sites/funcorporate/src/backend/base/utils.py
+++ b/sites/funcorporate/src/backend/base/utils.py
@@ -1,0 +1,18 @@
+import collections.abc
+
+
+def merge_dict(base_dict, update_dict):
+    """Utility for deep dictionary updates.
+
+    >>> d1 = {'k1':{'k11':{'a': 0, 'b': 1}}}
+    >>> d2 = {'k1':{'k11':{'b': 10}, 'k12':{'a': 3}}}
+    >>> merge_dict(d1, d2)
+    {'k1': {'k11': {'a': 0, 'b': 10}, 'k12':{'a': 3}}}
+
+    """
+    for key, value in update_dict.items():
+        if isinstance(value, collections.abc.Mapping):
+            base_dict[key] = merge_dict(base_dict.get(key, {}), value)
+        else:
+            base_dict[key] = value
+    return base_dict

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -12,6 +12,8 @@ from configurations import Configuration, values
 from richie.apps.courses.settings.mixins import RichieCoursesConfigurationMixin
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from base.utils import merge_dict
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join("/", "data")
 
@@ -321,6 +323,13 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         ],
     }
 
+    # Placeholders
+    CMS_PLACEHOLDER_CONF_OVERRIDES = {
+        "courses/cms/course_detail.html course_description": {
+            "limits": {"CKEditorPlugin": 2}
+        }
+    }
+
     # Search
     RICHIE_FILTERS_CONFIGURATION = [
         (
@@ -436,7 +445,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     environ_prefix=None,
                 ),
                 "TIMEOUT": values.IntegerValue(
-                    300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None,
+                    300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None
                 ),
             }
         }
@@ -490,6 +499,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")
 
+        # Customize DjangoCMS placeholders configuration
+        cls.CMS_PLACEHOLDER_CONF = merge_dict(
+            cls.CMS_PLACEHOLDER_CONF, cls.CMS_PLACEHOLDER_CONF_OVERRIDES
+        )
+
 
 class Development(Base):
     """
@@ -501,15 +515,9 @@ class Development(Base):
     DEBUG = True
     ALLOWED_HOSTS = ["*"]
 
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        }
-    }
+    CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
 
-    RICHIE_DEMO_NB_OBJECTS = {
-        "licences": 0
-    }
+    RICHIE_DEMO_NB_OBJECTS = {"licences": 0}
 
 
 class Test(Base):


### PR DESCRIPTION
## Purpose

Max number of plugins in course description needs to be temporarily relaxed because we have legacy content that is very long and that we can't rewrite in the short term.

## Proposal

- [x] Introduce a new setting and make a deep merge with the existing dictionary for placeholders configuration.
- [x] Bump max number of plugins in the course description to 2
