### PR TITLE
Add media files expiration lifecyle rule for demo site

### DIFF
--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -12,7 +12,18 @@ resource "aws_s3_bucket" "richie_media" {
   }
 
   versioning {
-    enabled = true
+    enabled = var.media_expiration > 0 ? false : true
+  }
+
+  dynamic "lifecycle_rule" {
+    for_each = var.media_expiration > 0 ? [1] : []
+    content {
+      id      = "expiration"
+      enabled = true
+      expiration {
+        days = var.media_expiration
+      }
+    }
   }
 
   tags = {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -19,3 +19,8 @@ variable "cloudfront_price_class" {
 variable "app_domain" {
   type = map
 }
+
+variable "media_expiration" {
+  type = number
+  default = 0
+}

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add expiration lifecycle rule on s3 bucket for demo site
+
 ## [1.0.0] - 2020-10-08
 
 ### Added

--- a/sites/demo/aws/config.tfvars
+++ b/sites/demo/aws/config.tfvars
@@ -5,3 +5,5 @@ app_domain = {
   preprod = "preprod.richie.oc.openfun.fr"
   staging = "staging.richie.oc.openfun.fr"
 }
+
+media_expiration = 2


### PR DESCRIPTION
## Purpose

The demo site is reset every night. This generates a huge amount of media files because new files are added at each reset! 

## Proposal

Adding an expiration lifecycle rule on the bucket is an easy way to keep it under control. I made it generic and configurable for each site.
