### PR TITLE
🚸(admin) returns a 403 response when upload in unsorted folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,66 +396,11 @@ workflows:
                 site: cnfpt
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
             - check-changelog:

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Return a 403 response when user tries to upload a file in unsorted folder
+
 ## [0.7.2] - 2020-11-15
 
 ### Fixed

--- a/sites/cnfpt/src/backend/base/admin.py
+++ b/sites/cnfpt/src/backend/base/admin.py
@@ -28,7 +28,7 @@ class CustomUserAdmin(UserAdmin):
 def ajax_upload(request, folder_id=None):
     """Disallow unsorted uploads."""
     if folder_id is None:
-        return JsonResponse({"error": _("Unsorted uploads are not allowed.")})
+        return JsonResponse({"error": _("Unsorted uploads are not allowed.")}, status=403)
 
     return filer_ajax_upload(request, folder_id=folder_id)
 

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Return a 403 response when user tries to upload a file in unsorted folder
+
 ## [1.0.1] - 2020-11-15
 
 ### Fixed

--- a/sites/funcampus/src/backend/base/admin.py
+++ b/sites/funcampus/src/backend/base/admin.py
@@ -28,7 +28,7 @@ class CustomUserAdmin(UserAdmin):
 def ajax_upload(request, folder_id=None):
     """Disallow unsorted uploads."""
     if folder_id is None:
-        return JsonResponse({"error": _("Unsorted uploads are not allowed.")})
+        return JsonResponse({"error": _("Unsorted uploads are not allowed.")}, status=403)
 
     return filer_ajax_upload(request, folder_id=folder_id)
 

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Return a 403 response when user tries to upload a file in unsorted folder
+
 ## [1.0.1] - 2020-11-15
 
 ### Fixed

--- a/sites/funcorporate/src/backend/base/admin.py
+++ b/sites/funcorporate/src/backend/base/admin.py
@@ -28,7 +28,7 @@ class CustomUserAdmin(UserAdmin):
 def ajax_upload(request, folder_id=None):
     """Disallow unsorted uploads."""
     if folder_id is None:
-        return JsonResponse({"error": _("Unsorted uploads are not allowed.")})
+        return JsonResponse({"error": _("Unsorted uploads are not allowed.")}, status=403)
 
     return filer_ajax_upload(request, folder_id=folder_id)
 

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Return a 403 response when user tries to upload a file in unsorted folder
+
 ## [0.15.2] - 2020-11-15
 
 ### Fixed

--- a/sites/funmooc/src/backend/base/admin.py
+++ b/sites/funmooc/src/backend/base/admin.py
@@ -28,7 +28,7 @@ class CustomUserAdmin(UserAdmin):
 def ajax_upload(request, folder_id=None):
     """Disallow unsorted uploads."""
     if folder_id is None:
-        return JsonResponse({"error": _("Unsorted uploads are not allowed.")})
+        return JsonResponse({"error": _("Unsorted uploads are not allowed.")}, status=403)
 
     return filer_ajax_upload(request, folder_id=folder_id)
 


### PR DESCRIPTION
## Purpose
Upload files in unsorted folder is forbidden but the error is currently unclear.

## Proposal
- [x] Return a 403 response When user try to upload a file in `Unsorted folder`. In this way Django-filer displays the error message included in the response body.

### Before
![image](https://user-images.githubusercontent.com/9265241/99818419-7d073580-2b4e-11eb-860c-310368883fa3.png)

### After
![Capture d’écran 2020-11-20 à 16 25 16](https://user-images.githubusercontent.com/9265241/99817276-03227c80-2b4d-11eb-9119-c301a98f5e88.png)
