### PR TITLE
⬆️(all) unpin django to 3.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,11 +396,66 @@ workflows:
                 site: cnfpt
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
             - check-changelog:

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Unpin Django now that django-admin-style 2.0.2 supports
+  the latest version 3.1.3
 - Return a 403 response when user tries to upload a file in unsorted folder
 
 ## [0.7.2] - 2020-11-15

--- a/sites/cnfpt/requirements/base.txt
+++ b/sites/cnfpt/requirements/base.txt
@@ -1,6 +1,4 @@
 boto3==1.9.96
-# /admin/cms/page is broken with Django>=3.1.2
-Django==3.1.1
 django-configurations==2.2
 # Superior versions of django-storages are not compatible with
 # ManifestStaticFilesStorage

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Unpin Django now that django-admin-style 2.0.2 supports
+  the latest version 3.1.3
+
 ## [1.1.2] - 2020-11-15
 
 ### Fixed

--- a/sites/demo/requirements/base.txt
+++ b/sites/demo/requirements/base.txt
@@ -1,6 +1,4 @@
 boto3==1.9.96
-# /admin/cms/page is broken with Django>=3.1.2
-Django==3.1.1
 django-configurations==2.2
 django-storages==1.10.1
 dockerflow==2020.10.0

--- a/sites/demo/src/frontend/yarn.lock
+++ b/sites/demo/src/frontend/yarn.lock
@@ -5717,7 +5717,7 @@ node-releases@^1.1.65:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.65.tgz#52d9579176bd60f23eba05c4438583f341944b81"
   integrity sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==
 
-nodemon@2.0.6, nodemon@^2.0.6:
+nodemon@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.6.tgz#1abe1937b463aaf62f0d52e2b7eaadf28cc2240d"
   integrity sha512-4I3YDSKXg6ltYpcnZeHompqac4E6JeAMpGm8tJnB9Y3T0ehasLa4139dJOcCrB93HHrUMsCrKtoAlXTqT5n4AQ==

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Unpin Django now that django-admin-style 2.0.2 supports
+  the latest version 3.1.3
 - Return a 403 response when user tries to upload a file in unsorted folder
 
 ## [1.0.1] - 2020-11-15

--- a/sites/funcampus/requirements/base.txt
+++ b/sites/funcampus/requirements/base.txt
@@ -1,6 +1,4 @@
 boto3==1.9.96
-# /admin/cms/page is broken with Django>=3.1.2
-Django==3.1.1
 django-configurations==2.2
 # Superior versions of django-storages are not compatible with
 # ManifestStaticFilesStorage

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Unpin Django now that django-admin-style 2.0.2 supports
+  the latest version 3.1.3
 - Return a 403 response when user tries to upload a file in unsorted folder
 
 ## [1.0.1] - 2020-11-15

--- a/sites/funcorporate/requirements/base.txt
+++ b/sites/funcorporate/requirements/base.txt
@@ -1,6 +1,4 @@
 boto3==1.9.96
-# /admin/cms/page is broken with Django>=3.1.2
-Django==3.1.1
 django-configurations==2.2
 # Superior versions of django-storages are not compatible with
 # ManifestStaticFilesStorage

--- a/sites/funcorporate/src/frontend/yarn.lock
+++ b/sites/funcorporate/src/frontend/yarn.lock
@@ -5631,7 +5631,7 @@ node-releases@^1.1.65:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.65.tgz#52d9579176bd60f23eba05c4438583f341944b81"
   integrity sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==
 
-nodemon@2.0.6, nodemon@^2.0.6:
+nodemon@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.6.tgz#1abe1937b463aaf62f0d52e2b7eaadf28cc2240d"
   integrity sha512-4I3YDSKXg6ltYpcnZeHompqac4E6JeAMpGm8tJnB9Y3T0ehasLa4139dJOcCrB93HHrUMsCrKtoAlXTqT5n4AQ==

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Unpin Django now that django-admin-style 2.0.2 supports
+  the latest version 3.1.3
 - Return a 403 response when user tries to upload a file in unsorted folder
 
 ## [0.15.2] - 2020-11-15

--- a/sites/funmooc/requirements/base.txt
+++ b/sites/funmooc/requirements/base.txt
@@ -1,6 +1,4 @@
 boto3==1.9.96
-# /admin/cms/page is broken with Django>=3.1.2
-Django==3.1.1
 django-configurations==2.2
 # Superior versions of django-storages are not compatible with
 # ManifestStaticFilesStorage

--- a/sites/funmooc/src/frontend/yarn.lock
+++ b/sites/funmooc/src/frontend/yarn.lock
@@ -5604,7 +5604,7 @@ node-releases@^1.1.65:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.65.tgz#52d9579176bd60f23eba05c4438583f341944b81"
   integrity sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==
 
-nodemon@2.0.6, nodemon@^2.0.6:
+nodemon@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.6.tgz#1abe1937b463aaf62f0d52e2b7eaadf28cc2240d"
   integrity sha512-4I3YDSKXg6ltYpcnZeHompqac4E6JeAMpGm8tJnB9Y3T0ehasLa4139dJOcCrB93HHrUMsCrKtoAlXTqT5n4AQ==


### PR DESCRIPTION
## Purpose
Since djangocms-admin-style 2.0.2 is released, admin interface issue has been fixed.
https://github.com/django-cms/djangocms-admin-style/blob/master/CHANGELOG.rst

## Proposal

- [x] Unpin Django to version 3.1.1.