### PR TITLE
Fallback cache when redis cache is down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
                 command: ~/.local/bin/flake8
                 name: Lint code with flake8
             - run:
-                command: ~/.local/bin/isort --recursive --check-only .
+                command: ~/.local/bin/isort --check-only .
                 name: Lint code with isort
             - run:
                 command: ~/.local/bin/black .

--- a/.circleci/src/jobs/@backend.yml
+++ b/.circleci/src/jobs/@backend.yml
@@ -43,7 +43,7 @@ lint-back:
         command: ~/.local/bin/flake8
     - run:
         name: Lint code with isort
-        command: ~/.local/bin/isort --recursive --check-only .
+        command: ~/.local/bin/isort --check-only .
     - run:
         name: Lint code with black
         command: ~/.local/bin/black .

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ lint-back-flake8: ## lint back-end python sources with flake8
 
 lint-back-isort: ## automatically re-arrange python imports in back-end code base
 	@echo 'lint:isort started…'
-	@$(COMPOSE_TEST_RUN_APP) isort --recursive --atomic .
+	@$(COMPOSE_TEST_RUN_APP) isort --atomic .
 .PHONY: lint-back-isort
 
 lint-back-pylint: ## lint back-end python sources with pylint

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix Sentry SDK initialization environment and release parameters
 
+### Added
+
+- Use a custom RedisCacheWithFallback cache to prevent denial of service
+  when Redis is down
+
 ## [0.9.2] - 2020-12-14
 
 ### Fixed

--- a/sites/cnfpt/src/backend/base/cache.py
+++ b/sites/cnfpt/src/backend/base/cache.py
@@ -1,0 +1,184 @@
+"""
+    RedisCache with a fallback cache to prevent denial of service if Redis is down
+    Freely inspired by django-cache-fallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback/
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
+
+from cms.cache import CMS_PAGE_CACHE_VERSION_KEY
+from django_redis.cache import RedisCache
+
+from .utils import throttle
+
+FALLBACK_CACHE_INVALIDATION_INTERVAL = 60  # seconds
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", __name__)
+logger = logging.getLogger(DJANGO_REDIS_LOGGER)
+
+
+class RedisCacheWithFallback(BaseCache):
+    """
+    BaseCache object with a redis_cache used as main cache
+    and the "fallback" aliased cache which takes over
+    in case redis_cache is down.
+    """
+
+    def __init__(self, server, params):
+        """
+        Instantiate the Redis Cache with server and params
+        and retrieve the cache with alias "fallback"
+        """
+        super().__init__(params)
+        self._redis_cache = RedisCache(server, params)
+        self._fallback_cache = caches["fallback"]
+
+    def _call_with_fallback(self, method, *args, **kwargs):
+        """
+        Try first to exec provided method through Redis cache instance,
+        in case of success, invalidate the fallback cache so it is clean and
+        ready for next failure,
+        in case of failure, logger reports the exception and
+        the fallback cache takes over.
+        """
+        try:
+            next_cache_state = self._call_redis_cache(method, args, kwargs)
+        except Exception as e:
+            logger.warning("[DEGRADED CACHE MODE] - Switch to fallback cache")
+            logger.exception(e)
+            return self._call_fallback_cache(method, args, kwargs)
+        else:
+            self._invalidate_fallback_cache()
+            return next_cache_state
+
+    def _call_redis_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the redis cache instance
+        """
+        return getattr(self._redis_cache, method)(*args, **kwargs)
+
+    def _call_fallback_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the fallback cache instance
+        """
+        return getattr(self._fallback_cache, method)(*args, **kwargs)
+
+    @throttle(FALLBACK_CACHE_INVALIDATION_INTERVAL)
+    def _invalidate_fallback_cache(self):
+        """
+        Invalidate cms page cache in the fallback cache.
+        """
+        self._fallback_cache.delete(CMS_PAGE_CACHE_VERSION_KEY)
+
+    def get_backend_timeout(self, *args, **kwargs):
+        """
+        Pass get_backend_timeout cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_backend_timeout", *args, **kwargs)
+
+    def make_key(self, *args, **kwargs):
+        """
+        Pass make_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("make_key", *args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        """
+        Pass add cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("add", *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Pass get cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get", *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        """
+        Pass set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set", *args, **kwargs)
+
+    def touch(self, *args, **kwargs):
+        """
+        Pass touch cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("touch", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """
+        Pass delete cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete", *args, **kwargs)
+
+    def get_many(self, *args, **kwargs):
+        """
+        Pass get_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_many", *args, **kwargs)
+
+    def get_or_set(self, *args, **kwargs):
+        """
+        Pass get_or_set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_or_set", *args, **kwargs)
+
+    def has_key(self, *args, **kwargs):
+        """
+        Pass has_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("has_key", *args, **kwargs)
+
+    def incr(self, *args, **kwargs):
+        """
+        Pass incr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr", *args, **kwargs)
+
+    def decr(self, *args, **kwargs):
+        """
+        Pass decr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr", *args, **kwargs)
+
+    def set_many(self, *args, **kwargs):
+        """
+        Pass set_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set_many", *args, **kwargs)
+
+    def delete_many(self, *args, **kwargs):
+        """
+        Pass delete_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete_many", *args, **kwargs)
+
+    def clear(self):
+        """
+        Pass clear cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("clear")
+
+    def validate_key(self, *args, **kwargs):
+        """
+        Pass validate_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("validate_key", *args, **kwargs)
+
+    def incr_version(self, *args, **kwargs):
+        """
+        Pass incr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr_version", *args, **kwargs)
+
+    def decr_version(self, *args, **kwargs):
+        """
+        Pass decr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr_version", *args, **kwargs)

--- a/sites/cnfpt/src/backend/base/tests/test_cache.py
+++ b/sites/cnfpt/src/backend/base/tests/test_cache.py
@@ -1,0 +1,159 @@
+"""Test funmooc cache plugin"""
+
+import datetime
+from unittest import mock
+
+from django.core.cache.backends.dummy import DummyCache
+from django.test import TestCase, override_settings
+
+from django_redis.cache import RedisCache
+
+from base.cache import RedisCacheWithFallback
+
+
+class RedisCacheWithFallbackTestCase(TestCase):
+    """
+    Test suite for the RedisCacheWithFallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback
+    """
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    def test_client(self):
+        """Test class instance of caches"""
+        client = RedisCacheWithFallback(None, {})
+        self.assertIs(type(client), RedisCacheWithFallback)
+        self.assertIs(type(client._redis_cache), RedisCache)
+        self.assertIs(type(client._fallback_cache), DummyCache)
+
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_redis_cache(self, redis_cache_mock, fallback_cache_mock):
+        """Test that redis_cache is used by default."""
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+    @mock.patch("base.cache.logger")
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_fallback_cache(
+        self, redis_cache_mock, fallback_cache_mock, logger_mock
+    ):
+        """
+        Test case when redis_cache raises an exception,
+        logger logs the exception then fallback_cache takes over
+        """
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+        redis_cache_mock.side_effect = Exception()
+        client.get("irrelevent")
+
+        logger_mock.warning.assert_called_with(
+            "[DEGRADED CACHE MODE] - Switch to fallback cache"
+        )
+        logger_mock.exception.assert_called_once()
+        fallback_cache_mock.assert_called_once()
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch.object(DummyCache, "delete")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_invalidate_fallback_cache(self, redis_cache_mock, delete_mock):
+        """
+        Test that fallback_cache is invalidated every 60 seconds
+        when Redis is up
+        """
+        now = datetime.datetime.now()
+
+        client = RedisCacheWithFallback(None, {})
+        client.get("round_0")
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # A second cache access should not delete the fallback cache again
+        client.get("round_1")
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 120 seconds later
+        # should delete the fallback cache again
+        read_time = now + datetime.timedelta(seconds=120)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_2")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 30 seconds later (<1 minute)
+        # should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_3")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute after
+        # the latest call should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_4")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute and 1 second after
+        # the latest call should delete the fallback cache again
+        read_time += datetime.timedelta(seconds=1)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_5")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()

--- a/sites/cnfpt/src/backend/base/utils.py
+++ b/sites/cnfpt/src/backend/base/utils.py
@@ -1,23 +1,5 @@
-import collections.abc
 from datetime import datetime, timedelta
 from functools import wraps
-
-
-def merge_dict(base_dict, update_dict):
-    """Utility for deep dictionary updates.
-
-    >>> d1 = {'k1':{'k11':{'a': 0, 'b': 1}}}
-    >>> d2 = {'k1':{'k11':{'b': 10}, 'k12':{'a': 3}}}
-    >>> merge_dict(d1, d2)
-    {'k1': {'k11': {'a': 0, 'b': 10}, 'k12':{'a': 3}}}
-
-    """
-    for key, value in update_dict.items():
-        if isinstance(value, collections.abc.Mapping):
-            base_dict[key] = merge_dict(base_dict.get(key, {}), value)
-        else:
-            base_dict[key] = value
-    return base_dict
 
 
 class throttle(object):

--- a/sites/cnfpt/src/backend/cnfpt/settings.py
+++ b/sites/cnfpt/src/backend/cnfpt/settings.py
@@ -460,7 +460,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         {
             "default": {
                 "BACKEND": values.Value(
-                    "django_redis.cache.RedisCache",
+                    "base.cache.RedisCacheWithFallback",
                     environ_name="CACHE_DEFAULT_BACKEND",
                     environ_prefix=None,
                 ),
@@ -470,14 +470,33 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     environ_prefix=None,
                 ),
                 "OPTIONS": values.DictValue(
-                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    {
+                        "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                    },
                     environ_name="CACHE_DEFAULT_OPTIONS",
                     environ_prefix=None,
                 ),
                 "TIMEOUT": values.IntegerValue(
                     300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None
                 ),
-            }
+            },
+            "fallback": {
+                "BACKEND": values.Value(
+                    "django.core.cache.backends.locmem.LocMemCache",
+                    environ_name="CACHE_FALLBACK_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    None,
+                    environ_name="CACHE_FALLBACK_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="CACHE_FALLBACK_OPTIONS",
+                    environ_prefix=None,
+                ),
+            },
         }
     )
 

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix Sentry SDK initialization environment and release parameters
 
+### Added
+
+- Use a custom RedisCacheWithFallback cache to prevent denial of service
+  when Redis is down
+
 ## [1.3.1] - 2020-12-09
 
 ### Fixed

--- a/sites/demo/src/backend/base/cache.py
+++ b/sites/demo/src/backend/base/cache.py
@@ -1,0 +1,184 @@
+"""
+    RedisCache with a fallback cache to prevent denial of service if Redis is down
+    Freely inspired by django-cache-fallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback/
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
+
+from cms.cache import CMS_PAGE_CACHE_VERSION_KEY
+from django_redis.cache import RedisCache
+
+from .utils import throttle
+
+FALLBACK_CACHE_INVALIDATION_INTERVAL = 60  # seconds
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", __name__)
+logger = logging.getLogger(DJANGO_REDIS_LOGGER)
+
+
+class RedisCacheWithFallback(BaseCache):
+    """
+    BaseCache object with a redis_cache used as main cache
+    and the "fallback" aliased cache which takes over
+    in case redis_cache is down.
+    """
+
+    def __init__(self, server, params):
+        """
+        Instantiate the Redis Cache with server and params
+        and retrieve the cache with alias "fallback"
+        """
+        super().__init__(params)
+        self._redis_cache = RedisCache(server, params)
+        self._fallback_cache = caches["fallback"]
+
+    def _call_with_fallback(self, method, *args, **kwargs):
+        """
+        Try first to exec provided method through Redis cache instance,
+        in case of success, invalidate the fallback cache so it is clean and
+        ready for next failure,
+        in case of failure, logger reports the exception and
+        the fallback cache takes over.
+        """
+        try:
+            next_cache_state = self._call_redis_cache(method, args, kwargs)
+        except Exception as e:
+            logger.warning("[DEGRADED CACHE MODE] - Switch to fallback cache")
+            logger.exception(e)
+            return self._call_fallback_cache(method, args, kwargs)
+        else:
+            self._invalidate_fallback_cache()
+            return next_cache_state
+
+    def _call_redis_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the redis cache instance
+        """
+        return getattr(self._redis_cache, method)(*args, **kwargs)
+
+    def _call_fallback_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the fallback cache instance
+        """
+        return getattr(self._fallback_cache, method)(*args, **kwargs)
+
+    @throttle(FALLBACK_CACHE_INVALIDATION_INTERVAL)  # 60 seconds
+    def _invalidate_fallback_cache(self):
+        """
+        Invalidate cms page cache in the fallback cache.
+        """
+        self._fallback_cache.delete(CMS_PAGE_CACHE_VERSION_KEY)
+
+    def get_backend_timeout(self, *args, **kwargs):
+        """
+        Pass get_backend_timeout cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_backend_timeout", *args, **kwargs)
+
+    def make_key(self, *args, **kwargs):
+        """
+        Pass make_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("make_key", *args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        """
+        Pass add cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("add", *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Pass get cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get", *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        """
+        Pass set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set", *args, **kwargs)
+
+    def touch(self, *args, **kwargs):
+        """
+        Pass touch cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("touch", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """
+        Pass delete cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete", *args, **kwargs)
+
+    def get_many(self, *args, **kwargs):
+        """
+        Pass get_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_many", *args, **kwargs)
+
+    def get_or_set(self, *args, **kwargs):
+        """
+        Pass get_or_set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_or_set", *args, **kwargs)
+
+    def has_key(self, *args, **kwargs):
+        """
+        Pass has_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("has_key", *args, **kwargs)
+
+    def incr(self, *args, **kwargs):
+        """
+        Pass incr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr", *args, **kwargs)
+
+    def decr(self, *args, **kwargs):
+        """
+        Pass decr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr", *args, **kwargs)
+
+    def set_many(self, *args, **kwargs):
+        """
+        Pass set_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set_many", *args, **kwargs)
+
+    def delete_many(self, *args, **kwargs):
+        """
+        Pass delete_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete_many", *args, **kwargs)
+
+    def clear(self):
+        """
+        Pass clear cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("clear")
+
+    def validate_key(self, *args, **kwargs):
+        """
+        Pass validate_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("validate_key", *args, **kwargs)
+
+    def incr_version(self, *args, **kwargs):
+        """
+        Pass incr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr_version", *args, **kwargs)
+
+    def decr_version(self, *args, **kwargs):
+        """
+        Pass decr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr_version", *args, **kwargs)

--- a/sites/demo/src/backend/base/tests/test_cache.py
+++ b/sites/demo/src/backend/base/tests/test_cache.py
@@ -1,0 +1,159 @@
+"""Test funmooc cache plugin"""
+
+import datetime
+from unittest import mock
+
+from django.core.cache.backends.dummy import DummyCache
+from django.test import TestCase, override_settings
+
+from django_redis.cache import RedisCache
+
+from base.cache import RedisCacheWithFallback
+
+
+class RedisCacheWithFallbackTestCase(TestCase):
+    """
+    Test suite for the RedisCacheWithFallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback
+    """
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    def test_client(self):
+        """Test class instance of caches"""
+        client = RedisCacheWithFallback(None, {})
+        self.assertIs(type(client), RedisCacheWithFallback)
+        self.assertIs(type(client._redis_cache), RedisCache)
+        self.assertIs(type(client._fallback_cache), DummyCache)
+
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_redis_cache(self, redis_cache_mock, fallback_cache_mock):
+        """Test that redis_cache is used by default."""
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+    @mock.patch("base.cache.logger")
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_fallback_cache(
+        self, redis_cache_mock, fallback_cache_mock, logger_mock
+    ):
+        """
+        Test case when redis_cache raises an exception,
+        logger logs the exception then fallback_cache takes over
+        """
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+        redis_cache_mock.side_effect = Exception()
+        client.get("irrelevent")
+
+        logger_mock.warning.assert_called_with(
+            "[DEGRADED CACHE MODE] - Switch to fallback cache"
+        )
+        logger_mock.exception.assert_called_once()
+        fallback_cache_mock.assert_called_once()
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch.object(DummyCache, "delete")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_invalidate_fallback_cache(self, redis_cache_mock, delete_mock):
+        """
+        Test that fallback_cache is invalidated every 60 seconds
+        when Redis is up
+        """
+        now = datetime.datetime.now()
+
+        client = RedisCacheWithFallback(None, {})
+        client.get("round_0")
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # A second cache access should not delete the fallback cache again
+        client.get("round_1")
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 120 seconds later
+        # should delete the fallback cache again
+        read_time = now + datetime.timedelta(seconds=120)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_2")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 30 seconds later (<1 minute)
+        # should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_3")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute after
+        # the latest call should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_4")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute and 1 second after
+        # the latest call should delete the fallback cache again
+        read_time += datetime.timedelta(seconds=1)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_5")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()

--- a/sites/demo/src/backend/base/utils.py
+++ b/sites/demo/src/backend/base/utils.py
@@ -1,23 +1,5 @@
-import collections.abc
 from datetime import datetime, timedelta
 from functools import wraps
-
-
-def merge_dict(base_dict, update_dict):
-    """Utility for deep dictionary updates.
-
-    >>> d1 = {'k1':{'k11':{'a': 0, 'b': 1}}}
-    >>> d2 = {'k1':{'k11':{'b': 10}, 'k12':{'a': 3}}}
-    >>> merge_dict(d1, d2)
-    {'k1': {'k11': {'a': 0, 'b': 10}, 'k12':{'a': 3}}}
-
-    """
-    for key, value in update_dict.items():
-        if isinstance(value, collections.abc.Mapping):
-            base_dict[key] = merge_dict(base_dict.get(key, {}), value)
-        else:
-            base_dict[key] = value
-    return base_dict
 
 
 class throttle(object):

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -459,7 +459,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         {
             "default": {
                 "BACKEND": values.Value(
-                    "django_redis.cache.RedisCache",
+                    "base.cache.RedisCacheWithFallback",
                     environ_name="CACHE_DEFAULT_BACKEND",
                     environ_prefix=None,
                 ),
@@ -469,16 +469,33 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     environ_prefix=None,
                 ),
                 "OPTIONS": values.DictValue(
-                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    {
+                        "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                    },
                     environ_name="CACHE_DEFAULT_OPTIONS",
                     environ_prefix=None,
                 ),
                 "TIMEOUT": values.IntegerValue(
-                    300,
-                    environ_name="CACHE_DEFAULT_TIMEOUT",
+                    300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None
+                ),
+            },
+            "fallback": {
+                "BACKEND": values.Value(
+                    "django.core.cache.backends.locmem.LocMemCache",
+                    environ_name="CACHE_FALLBACK_BACKEND",
                     environ_prefix=None,
                 ),
-            }
+                "LOCATION": values.Value(
+                    None,
+                    environ_name="CACHE_FALLBACK_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="CACHE_FALLBACK_OPTIONS",
+                    environ_prefix=None,
+                ),
+            },
         }
     )
 

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix Sentry SDK initialization environment and release parameters
 
+### Added
+
+- Use a custom RedisCacheWithFallback cache to prevent denial of service
+  when Redis is down
+
 ## [1.2.1] - 2020-12-09
 
 ### Fixed

--- a/sites/funcampus/src/backend/base/cache.py
+++ b/sites/funcampus/src/backend/base/cache.py
@@ -1,0 +1,184 @@
+"""
+    RedisCache with a fallback cache to prevent denial of service if Redis is down
+    Freely inspired by django-cache-fallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback/
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
+
+from cms.cache import CMS_PAGE_CACHE_VERSION_KEY
+from django_redis.cache import RedisCache
+
+from .utils import throttle
+
+FALLBACK_CACHE_INVALIDATION_INTERVAL = 60  # seconds
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", __name__)
+logger = logging.getLogger(DJANGO_REDIS_LOGGER)
+
+
+class RedisCacheWithFallback(BaseCache):
+    """
+    BaseCache object with a redis_cache used as main cache
+    and the "fallback" aliased cache which takes over
+    in case redis_cache is down.
+    """
+
+    def __init__(self, server, params):
+        """
+        Instantiate the Redis Cache with server and params
+        and retrieve the cache with alias "fallback"
+        """
+        super().__init__(params)
+        self._redis_cache = RedisCache(server, params)
+        self._fallback_cache = caches["fallback"]
+
+    def _call_with_fallback(self, method, *args, **kwargs):
+        """
+        Try first to exec provided method through Redis cache instance,
+        in case of success, invalidate the fallback cache so it is clean and
+        ready for next failure,
+        in case of failure, logger reports the exception and
+        the fallback cache takes over.
+        """
+        try:
+            next_cache_state = self._call_redis_cache(method, args, kwargs)
+        except Exception as e:
+            logger.warning("[DEGRADED CACHE MODE] - Switch to fallback cache")
+            logger.exception(e)
+            return self._call_fallback_cache(method, args, kwargs)
+        else:
+            self._invalidate_fallback_cache()
+            return next_cache_state
+
+    def _call_redis_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the redis cache instance
+        """
+        return getattr(self._redis_cache, method)(*args, **kwargs)
+
+    def _call_fallback_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the fallback cache instance
+        """
+        return getattr(self._fallback_cache, method)(*args, **kwargs)
+
+    @throttle(FALLBACK_CACHE_INVALIDATION_INTERVAL)  # 60 seconds
+    def _invalidate_fallback_cache(self):
+        """
+        Invalidate cms page cache in the fallback cache.
+        """
+        self._fallback_cache.delete(CMS_PAGE_CACHE_VERSION_KEY)
+
+    def get_backend_timeout(self, *args, **kwargs):
+        """
+        Pass get_backend_timeout cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_backend_timeout", *args, **kwargs)
+
+    def make_key(self, *args, **kwargs):
+        """
+        Pass make_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("make_key", *args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        """
+        Pass add cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("add", *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Pass get cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get", *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        """
+        Pass set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set", *args, **kwargs)
+
+    def touch(self, *args, **kwargs):
+        """
+        Pass touch cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("touch", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """
+        Pass delete cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete", *args, **kwargs)
+
+    def get_many(self, *args, **kwargs):
+        """
+        Pass get_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_many", *args, **kwargs)
+
+    def get_or_set(self, *args, **kwargs):
+        """
+        Pass get_or_set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_or_set", *args, **kwargs)
+
+    def has_key(self, *args, **kwargs):
+        """
+        Pass has_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("has_key", *args, **kwargs)
+
+    def incr(self, *args, **kwargs):
+        """
+        Pass incr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr", *args, **kwargs)
+
+    def decr(self, *args, **kwargs):
+        """
+        Pass decr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr", *args, **kwargs)
+
+    def set_many(self, *args, **kwargs):
+        """
+        Pass set_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set_many", *args, **kwargs)
+
+    def delete_many(self, *args, **kwargs):
+        """
+        Pass delete_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete_many", *args, **kwargs)
+
+    def clear(self):
+        """
+        Pass clear cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("clear")
+
+    def validate_key(self, *args, **kwargs):
+        """
+        Pass validate_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("validate_key", *args, **kwargs)
+
+    def incr_version(self, *args, **kwargs):
+        """
+        Pass incr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr_version", *args, **kwargs)
+
+    def decr_version(self, *args, **kwargs):
+        """
+        Pass decr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr_version", *args, **kwargs)

--- a/sites/funcampus/src/backend/base/tests/test_cache.py
+++ b/sites/funcampus/src/backend/base/tests/test_cache.py
@@ -1,0 +1,159 @@
+"""Test funmooc cache plugin"""
+
+import datetime
+from unittest import mock
+
+from django.core.cache.backends.dummy import DummyCache
+from django.test import TestCase, override_settings
+
+from django_redis.cache import RedisCache
+
+from base.cache import RedisCacheWithFallback
+
+
+class RedisCacheWithFallbackTestCase(TestCase):
+    """
+    Test suite for the RedisCacheWithFallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback
+    """
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    def test_client(self):
+        """Test class instance of caches"""
+        client = RedisCacheWithFallback(None, {})
+        self.assertIs(type(client), RedisCacheWithFallback)
+        self.assertIs(type(client._redis_cache), RedisCache)
+        self.assertIs(type(client._fallback_cache), DummyCache)
+
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_redis_cache(self, redis_cache_mock, fallback_cache_mock):
+        """Test that redis_cache is used by default."""
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+    @mock.patch("base.cache.logger")
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_fallback_cache(
+        self, redis_cache_mock, fallback_cache_mock, logger_mock
+    ):
+        """
+        Test case when redis_cache raises an exception,
+        logger logs the exception then fallback_cache takes over
+        """
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+        redis_cache_mock.side_effect = Exception()
+        client.get("irrelevent")
+
+        logger_mock.warning.assert_called_with(
+            "[DEGRADED CACHE MODE] - Switch to fallback cache"
+        )
+        logger_mock.exception.assert_called_once()
+        fallback_cache_mock.assert_called_once()
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch.object(DummyCache, "delete")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_invalidate_fallback_cache(self, redis_cache_mock, delete_mock):
+        """
+        Test that fallback_cache is invalidated every 60 seconds
+        when Redis is up
+        """
+        now = datetime.datetime.now()
+
+        client = RedisCacheWithFallback(None, {})
+        client.get("round_0")
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # A second cache access should not delete the fallback cache again
+        client.get("round_1")
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 120 seconds later
+        # should delete the fallback cache again
+        read_time = now + datetime.timedelta(seconds=120)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_2")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 30 seconds later (<1 minute)
+        # should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_3")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute after
+        # the latest call should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_4")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute and 1 second after
+        # the latest call should delete the fallback cache again
+        read_time += datetime.timedelta(seconds=1)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_5")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()

--- a/sites/funcampus/src/backend/base/utils.py
+++ b/sites/funcampus/src/backend/base/utils.py
@@ -1,23 +1,5 @@
-import collections.abc
 from datetime import datetime, timedelta
 from functools import wraps
-
-
-def merge_dict(base_dict, update_dict):
-    """Utility for deep dictionary updates.
-
-    >>> d1 = {'k1':{'k11':{'a': 0, 'b': 1}}}
-    >>> d2 = {'k1':{'k11':{'b': 10}, 'k12':{'a': 3}}}
-    >>> merge_dict(d1, d2)
-    {'k1': {'k11': {'a': 0, 'b': 10}, 'k12':{'a': 3}}}
-
-    """
-    for key, value in update_dict.items():
-        if isinstance(value, collections.abc.Mapping):
-            base_dict[key] = merge_dict(base_dict.get(key, {}), value)
-        else:
-            base_dict[key] = value
-    return base_dict
 
 
 class throttle(object):

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -453,7 +453,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         {
             "default": {
                 "BACKEND": values.Value(
-                    "django_redis.cache.RedisCache",
+                    "base.cache.RedisCacheWithFallback",
                     environ_name="CACHE_DEFAULT_BACKEND",
                     environ_prefix=None,
                 ),
@@ -463,7 +463,9 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     environ_prefix=None,
                 ),
                 "OPTIONS": values.DictValue(
-                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    {
+                        "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                    },
                     environ_name="CACHE_DEFAULT_OPTIONS",
                     environ_prefix=None,
                 ),
@@ -472,7 +474,24 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     environ_name="CACHE_DEFAULT_TIMEOUT",
                     environ_prefix=None,
                 ),
-            }
+            },
+            "fallback": {
+                "BACKEND": values.Value(
+                    "django.core.cache.backends.locmem.LocMemCache",
+                    environ_name="CACHE_FALLBACK_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    None,
+                    environ_name="CACHE_FALLBACK_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="CACHE_FALLBACK_OPTIONS",
+                    environ_prefix=None,
+                ),
+            },
         }
     )
 

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix Sentry SDK initialization environment and release parameters
 
+### Added
+
+- Use a custom RedisCacheWithFallback cache to prevent denial of service
+  when Redis is down
+
 ## [1.2.1] - 2020-12-09
 
 ### Fixed

--- a/sites/funcorporate/src/backend/base/cache.py
+++ b/sites/funcorporate/src/backend/base/cache.py
@@ -1,0 +1,184 @@
+"""
+    RedisCache with a fallback cache to prevent denial of service if Redis is down
+    Freely inspired by django-cache-fallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback/
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
+
+from cms.cache import CMS_PAGE_CACHE_VERSION_KEY
+from django_redis.cache import RedisCache
+
+from .utils import throttle
+
+FALLBACK_CACHE_INVALIDATION_INTERVAL = 60  # seconds
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", __name__)
+logger = logging.getLogger(DJANGO_REDIS_LOGGER)
+
+
+class RedisCacheWithFallback(BaseCache):
+    """
+    BaseCache object with a redis_cache used as main cache
+    and the "fallback" aliased cache which takes over
+    in case redis_cache is down.
+    """
+
+    def __init__(self, server, params):
+        """
+        Instantiate the Redis Cache with server and params
+        and retrieve the cache with alias "fallback"
+        """
+        super().__init__(params)
+        self._redis_cache = RedisCache(server, params)
+        self._fallback_cache = caches["fallback"]
+
+    def _call_with_fallback(self, method, *args, **kwargs):
+        """
+        Try first to exec provided method through Redis cache instance,
+        in case of success, invalidate the fallback cache so it is clean and
+        ready for next failure,
+        in case of failure, logger reports the exception and
+        the fallback cache takes over.
+        """
+        try:
+            next_cache_state = self._call_redis_cache(method, args, kwargs)
+        except Exception as e:
+            logger.warning("[DEGRADED CACHE MODE] - Switch to fallback cache")
+            logger.exception(e)
+            return self._call_fallback_cache(method, args, kwargs)
+        else:
+            self._invalidate_fallback_cache()
+            return next_cache_state
+
+    def _call_redis_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the redis cache instance
+        """
+        return getattr(self._redis_cache, method)(*args, **kwargs)
+
+    def _call_fallback_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the fallback cache instance
+        """
+        return getattr(self._fallback_cache, method)(*args, **kwargs)
+
+    @throttle(FALLBACK_CACHE_INVALIDATION_INTERVAL)  # 60 seconds
+    def _invalidate_fallback_cache(self):
+        """
+        Invalidate cms page cache in the fallback cache.
+        """
+        self._fallback_cache.delete(CMS_PAGE_CACHE_VERSION_KEY)
+
+    def get_backend_timeout(self, *args, **kwargs):
+        """
+        Pass get_backend_timeout cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_backend_timeout", *args, **kwargs)
+
+    def make_key(self, *args, **kwargs):
+        """
+        Pass make_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("make_key", *args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        """
+        Pass add cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("add", *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Pass get cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get", *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        """
+        Pass set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set", *args, **kwargs)
+
+    def touch(self, *args, **kwargs):
+        """
+        Pass touch cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("touch", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """
+        Pass delete cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete", *args, **kwargs)
+
+    def get_many(self, *args, **kwargs):
+        """
+        Pass get_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_many", *args, **kwargs)
+
+    def get_or_set(self, *args, **kwargs):
+        """
+        Pass get_or_set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_or_set", *args, **kwargs)
+
+    def has_key(self, *args, **kwargs):
+        """
+        Pass has_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("has_key", *args, **kwargs)
+
+    def incr(self, *args, **kwargs):
+        """
+        Pass incr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr", *args, **kwargs)
+
+    def decr(self, *args, **kwargs):
+        """
+        Pass decr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr", *args, **kwargs)
+
+    def set_many(self, *args, **kwargs):
+        """
+        Pass set_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set_many", *args, **kwargs)
+
+    def delete_many(self, *args, **kwargs):
+        """
+        Pass delete_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete_many", *args, **kwargs)
+
+    def clear(self):
+        """
+        Pass clear cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("clear")
+
+    def validate_key(self, *args, **kwargs):
+        """
+        Pass validate_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("validate_key", *args, **kwargs)
+
+    def incr_version(self, *args, **kwargs):
+        """
+        Pass incr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr_version", *args, **kwargs)
+
+    def decr_version(self, *args, **kwargs):
+        """
+        Pass decr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr_version", *args, **kwargs)

--- a/sites/funcorporate/src/backend/base/tests/test_cache.py
+++ b/sites/funcorporate/src/backend/base/tests/test_cache.py
@@ -1,0 +1,159 @@
+"""Test funmooc cache plugin"""
+
+import datetime
+from unittest import mock
+
+from django.core.cache.backends.dummy import DummyCache
+from django.test import TestCase, override_settings
+
+from django_redis.cache import RedisCache
+
+from base.cache import RedisCacheWithFallback
+
+
+class RedisCacheWithFallbackTestCase(TestCase):
+    """
+    Test suite for the RedisCacheWithFallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback
+    """
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    def test_client(self):
+        """Test class instance of caches"""
+        client = RedisCacheWithFallback(None, {})
+        self.assertIs(type(client), RedisCacheWithFallback)
+        self.assertIs(type(client._redis_cache), RedisCache)
+        self.assertIs(type(client._fallback_cache), DummyCache)
+
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_redis_cache(self, redis_cache_mock, fallback_cache_mock):
+        """Test that redis_cache is used by default."""
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+    @mock.patch("base.cache.logger")
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_fallback_cache(
+        self, redis_cache_mock, fallback_cache_mock, logger_mock
+    ):
+        """
+        Test case when redis_cache raises an exception,
+        logger logs the exception then fallback_cache takes over
+        """
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+        redis_cache_mock.side_effect = Exception()
+        client.get("irrelevent")
+
+        logger_mock.warning.assert_called_with(
+            "[DEGRADED CACHE MODE] - Switch to fallback cache"
+        )
+        logger_mock.exception.assert_called_once()
+        fallback_cache_mock.assert_called_once()
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch.object(DummyCache, "delete")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_invalidate_fallback_cache(self, redis_cache_mock, delete_mock):
+        """
+        Test that fallback_cache is invalidated every 60 seconds
+        when Redis is up
+        """
+        now = datetime.datetime.now()
+
+        client = RedisCacheWithFallback(None, {})
+        client.get("round_0")
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # A second cache access should not delete the fallback cache again
+        client.get("round_1")
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 120 seconds later
+        # should delete the fallback cache again
+        read_time = now + datetime.timedelta(seconds=120)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_2")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 30 seconds later (<1 minute)
+        # should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_3")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute after
+        # the latest call should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_4")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute and 1 second after
+        # the latest call should delete the fallback cache again
+        read_time += datetime.timedelta(seconds=1)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_5")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -443,7 +443,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         {
             "default": {
                 "BACKEND": values.Value(
-                    "django_redis.cache.RedisCache",
+                    "base.cache.RedisCacheWithFallback",
                     environ_name="CACHE_DEFAULT_BACKEND",
                     environ_prefix=None,
                 ),
@@ -453,14 +453,33 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     environ_prefix=None,
                 ),
                 "OPTIONS": values.DictValue(
-                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    {
+                        "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                    },
                     environ_name="CACHE_DEFAULT_OPTIONS",
                     environ_prefix=None,
                 ),
                 "TIMEOUT": values.IntegerValue(
                     300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None
                 ),
-            }
+            },
+            "fallback": {
+                "BACKEND": values.Value(
+                    "django.core.cache.backends.locmem.LocMemCache",
+                    environ_name="CACHE_FALLBACK_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    None,
+                    environ_name="CACHE_FALLBACK_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="CACHE_FALLBACK_OPTIONS",
+                    environ_prefix=None,
+                ),
+            },
         }
     )
 

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix Sentry SDK initialization environment and release parameters
 
+### Added
+
+- Use a custom RedisCacheWithFallback cache to prevent denial of service
+  when Redis is down
+
 ## [0.18.0] - 2020-12-11
 
 ### Changed

--- a/sites/funmooc/src/backend/base/cache.py
+++ b/sites/funmooc/src/backend/base/cache.py
@@ -1,0 +1,184 @@
+"""
+    RedisCache with a fallback cache to prevent denial of service if Redis is down
+    Freely inspired by django-cache-fallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback/
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
+
+from cms.cache import CMS_PAGE_CACHE_VERSION_KEY
+from django_redis.cache import RedisCache
+
+from .utils import throttle
+
+FALLBACK_CACHE_INVALIDATION_INTERVAL = 60  # seconds
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", __name__)
+logger = logging.getLogger(DJANGO_REDIS_LOGGER)
+
+
+class RedisCacheWithFallback(BaseCache):
+    """
+    BaseCache object with a redis_cache used as main cache
+    and the "fallback" aliased cache which takes over
+    in case redis_cache is down.
+    """
+
+    def __init__(self, server, params):
+        """
+        Instantiate the Redis Cache with server and params
+        and retrieve the cache with alias "fallback"
+        """
+        super().__init__(params)
+        self._redis_cache = RedisCache(server, params)
+        self._fallback_cache = caches["fallback"]
+
+    def _call_with_fallback(self, method, *args, **kwargs):
+        """
+        Try first to exec provided method through Redis cache instance,
+        in case of success, invalidate the fallback cache so it is clean and
+        ready for next failure,
+        in case of failure, logger reports the exception and
+        the fallback cache takes over.
+        """
+        try:
+            next_cache_state = self._call_redis_cache(method, args, kwargs)
+        except Exception as e:
+            logger.warning("[DEGRADED CACHE MODE] - Switch to fallback cache")
+            logger.exception(e)
+            return self._call_fallback_cache(method, args, kwargs)
+        else:
+            self._invalidate_fallback_cache()
+            return next_cache_state
+
+    def _call_redis_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the redis cache instance
+        """
+        return getattr(self._redis_cache, method)(*args, **kwargs)
+
+    def _call_fallback_cache(self, method, args, kwargs):
+        """
+        Exec the provided method through the fallback cache instance
+        """
+        return getattr(self._fallback_cache, method)(*args, **kwargs)
+
+    @throttle(FALLBACK_CACHE_INVALIDATION_INTERVAL)  # 60 seconds
+    def _invalidate_fallback_cache(self):
+        """
+        Invalidate cms page cache in the fallback cache.
+        """
+        self._fallback_cache.delete(CMS_PAGE_CACHE_VERSION_KEY)
+
+    def get_backend_timeout(self, *args, **kwargs):
+        """
+        Pass get_backend_timeout cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_backend_timeout", *args, **kwargs)
+
+    def make_key(self, *args, **kwargs):
+        """
+        Pass make_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("make_key", *args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        """
+        Pass add cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("add", *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Pass get cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get", *args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        """
+        Pass set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set", *args, **kwargs)
+
+    def touch(self, *args, **kwargs):
+        """
+        Pass touch cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("touch", *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """
+        Pass delete cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete", *args, **kwargs)
+
+    def get_many(self, *args, **kwargs):
+        """
+        Pass get_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_many", *args, **kwargs)
+
+    def get_or_set(self, *args, **kwargs):
+        """
+        Pass get_or_set cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("get_or_set", *args, **kwargs)
+
+    def has_key(self, *args, **kwargs):
+        """
+        Pass has_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("has_key", *args, **kwargs)
+
+    def incr(self, *args, **kwargs):
+        """
+        Pass incr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr", *args, **kwargs)
+
+    def decr(self, *args, **kwargs):
+        """
+        Pass decr cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr", *args, **kwargs)
+
+    def set_many(self, *args, **kwargs):
+        """
+        Pass set_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("set_many", *args, **kwargs)
+
+    def delete_many(self, *args, **kwargs):
+        """
+        Pass delete_many cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("delete_many", *args, **kwargs)
+
+    def clear(self):
+        """
+        Pass clear cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("clear")
+
+    def validate_key(self, *args, **kwargs):
+        """
+        Pass validate_key cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("validate_key", *args, **kwargs)
+
+    def incr_version(self, *args, **kwargs):
+        """
+        Pass incr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("incr_version", *args, **kwargs)
+
+    def decr_version(self, *args, **kwargs):
+        """
+        Pass decr_version cache method to _call_with_fallback
+        """
+        return self._call_with_fallback("decr_version", *args, **kwargs)

--- a/sites/funmooc/src/backend/base/tests/test_cache.py
+++ b/sites/funmooc/src/backend/base/tests/test_cache.py
@@ -1,0 +1,159 @@
+"""Test funmooc cache plugin"""
+
+import datetime
+from unittest import mock
+
+from django.core.cache.backends.dummy import DummyCache
+from django.test import TestCase, override_settings
+
+from django_redis.cache import RedisCache
+
+from base.cache import RedisCacheWithFallback
+
+
+class RedisCacheWithFallbackTestCase(TestCase):
+    """
+    Test suite for the RedisCacheWithFallback
+
+    Credits:
+    - https://github.com/Kub-AT/django-cache-fallback
+    """
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    def test_client(self):
+        """Test class instance of caches"""
+        client = RedisCacheWithFallback(None, {})
+        self.assertIs(type(client), RedisCacheWithFallback)
+        self.assertIs(type(client._redis_cache), RedisCache)
+        self.assertIs(type(client._fallback_cache), DummyCache)
+
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_redis_cache(self, redis_cache_mock, fallback_cache_mock):
+        """Test that redis_cache is used by default."""
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+    @mock.patch("base.cache.logger")
+    @mock.patch.object(RedisCacheWithFallback, "_call_fallback_cache")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_get_fallback_cache(
+        self, redis_cache_mock, fallback_cache_mock, logger_mock
+    ):
+        """
+        Test case when redis_cache raises an exception,
+        logger logs the exception then fallback_cache takes over
+        """
+        client = RedisCacheWithFallback(None, {})
+        client.get("irrelevent")
+
+        redis_cache_mock.assert_called_once()
+        fallback_cache_mock.assert_not_called()
+
+        redis_cache_mock.side_effect = Exception()
+        client.get("irrelevent")
+
+        logger_mock.warning.assert_called_with(
+            "[DEGRADED CACHE MODE] - Switch to fallback cache"
+        )
+        logger_mock.exception.assert_called_once()
+        fallback_cache_mock.assert_called_once()
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "base.cache.RedisCacheWithFallback",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {
+                    "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                },
+            },
+            "fallback": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    @mock.patch.object(DummyCache, "delete")
+    @mock.patch.object(RedisCacheWithFallback, "_call_redis_cache")
+    def test_invalidate_fallback_cache(self, redis_cache_mock, delete_mock):
+        """
+        Test that fallback_cache is invalidated every 60 seconds
+        when Redis is up
+        """
+        now = datetime.datetime.now()
+
+        client = RedisCacheWithFallback(None, {})
+        client.get("round_0")
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # A second cache access should not delete the fallback cache again
+        client.get("round_1")
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 120 seconds later
+        # should delete the fallback cache again
+        read_time = now + datetime.timedelta(seconds=120)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_2")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache 30 seconds later (<1 minute)
+        # should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_3")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute after
+        # the latest call should not delete the fallback cache again
+        read_time += datetime.timedelta(seconds=30)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_4")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_not_called()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()
+
+        # Another call to Redis cache exactly 1 minute and 1 second after
+        # the latest call should delete the fallback cache again
+        read_time += datetime.timedelta(seconds=1)
+        with mock.patch("base.utils.datetime") as mock_datetime:
+            mock_datetime.now.return_value = read_time
+            client.get("round_5")
+
+        redis_cache_mock.assert_called_once()
+        delete_mock.assert_called_once()
+        redis_cache_mock.reset_mock()
+        delete_mock.reset_mock()

--- a/sites/funmooc/src/backend/base/utils.py
+++ b/sites/funmooc/src/backend/base/utils.py
@@ -1,23 +1,5 @@
-import collections.abc
 from datetime import datetime, timedelta
 from functools import wraps
-
-
-def merge_dict(base_dict, update_dict):
-    """Utility for deep dictionary updates.
-
-    >>> d1 = {'k1':{'k11':{'a': 0, 'b': 1}}}
-    >>> d2 = {'k1':{'k11':{'b': 10}, 'k12':{'a': 3}}}
-    >>> merge_dict(d1, d2)
-    {'k1': {'k11': {'a': 0, 'b': 10}, 'k12':{'a': 3}}}
-
-    """
-    for key, value in update_dict.items():
-        if isinstance(value, collections.abc.Mapping):
-            base_dict[key] = merge_dict(base_dict.get(key, {}), value)
-        else:
-            base_dict[key] = value
-    return base_dict
 
 
 class throttle(object):

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -547,7 +547,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         {
             "default": {
                 "BACKEND": values.Value(
-                    "django_redis.cache.RedisCache",
+                    "base.cache.RedisCacheWithFallback",
                     environ_name="CACHE_DEFAULT_BACKEND",
                     environ_prefix=None,
                 ),
@@ -557,14 +557,33 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     environ_prefix=None,
                 ),
                 "OPTIONS": values.DictValue(
-                    {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+                    {
+                        "CLIENT_CLASS": "richie.apps.core.cache.SentinelClient",
+                    },
                     environ_name="CACHE_DEFAULT_OPTIONS",
                     environ_prefix=None,
                 ),
                 "TIMEOUT": values.IntegerValue(
                     300, environ_name="CACHE_DEFAULT_TIMEOUT", environ_prefix=None
                 ),
-            }
+            },
+            "fallback": {
+                "BACKEND": values.Value(
+                    "django.core.cache.backends.locmem.LocMemCache",
+                    environ_name="CACHE_FALLBACK_BACKEND",
+                    environ_prefix=None,
+                ),
+                "LOCATION": values.Value(
+                    None,
+                    environ_name="CACHE_FALLBACK_LOCATION",
+                    environ_prefix=None,
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="CACHE_FALLBACK_OPTIONS",
+                    environ_prefix=None,
+                ),
+            },
         }
     )
 


### PR DESCRIPTION
### Purpose

When Redis cache is out of service, an exception is catched and the platform is down which is awkward.

### Proposal

- [x] Create a custom cache `RedisCacheWithFallback` which is able to use a fallback cache in case redis is down.