### PR TITLE
Add redirects from openedx routes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: master
+                        ignore: /.*/
                 name: check-changelog-cnfpt
                 site: cnfpt
             - lint-changelog:
@@ -399,7 +399,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: master
+                        ignore: /.*/
                 name: check-changelog-demo
                 site: demo
             - lint-changelog:
@@ -461,7 +461,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: master
+                        ignore: /.*/
                 name: check-changelog-funcampus
                 site: funcampus
             - lint-changelog:
@@ -523,7 +523,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: master
+                        ignore: /.*/
                 name: check-changelog-funcorporate
                 site: funcorporate
             - lint-changelog:
@@ -649,7 +649,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: ""
+                ci_update_options: --ignore-changelog
                 filters:
                     branches:
                         ignore: master

--- a/sites/cnfpt/src/backend/cnfpt/settings.py
+++ b/sites/cnfpt/src/backend/cnfpt/settings.py
@@ -616,6 +616,7 @@ class Development(Base):
 
 class Test(Base):
     """Test environment settings"""
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 
 class ContinuousIntegration(Test):

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -577,6 +577,7 @@ class Development(Base):
 
 class Test(Base):
     """Test environment settings"""
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 
 class ContinuousIntegration(Test):

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -609,6 +609,7 @@ class Development(Base):
 
 class Test(Base):
     """Test environment settings"""
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 
 class ContinuousIntegration(Test):

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -568,6 +568,7 @@ class Development(Base):
 
 class Test(Base):
     """Test environment settings"""
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 
 class ContinuousIntegration(Test):

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,11 +8,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Redirect old OpenEdX course urls to new richie course pages
+
 ### Changed
 
 - Set `CMS_PAGETREE_DESCENDANTS_LIMIT` setting to control pagetree search node
   foldability according to its child node count
-  
+
 ## [0.19.0] - 2021-01-14
 
 ### Changed

--- a/sites/funmooc/src/backend/base/tests/test_views.py
+++ b/sites/funmooc/src/backend/base/tests/test_views.py
@@ -1,0 +1,87 @@
+"""Test fun-mooc views."""
+from django.test import TestCase
+
+from richie.apps.core.factories import PageFactory, TitleFactory
+from richie.apps.courses.factories import CourseFactory, OrganizationFactory
+
+
+class CoursesEdxRedirectViewsTestCase(TestCase):
+    """Test the "redirect_edx_courses" view."""
+
+    def test_views_redirect_edx_courses_success(self):
+        """OpenEdX course urls are redirected to the corresponding page in richie."""
+        course = CourseFactory(
+            code="abc", page_title="Physique 101", should_publish=True
+        )
+        TitleFactory(page=course.extended_object, language="en", title="Physics 101")
+        course.extended_object.publish("en")
+
+        response = self.client.get("/courses/course-v1:sorbonne+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/physique-101/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
+    def test_views_redirect_edx_courses_fallback_organization(self):
+        """
+        OpenEdX course urls are redirected to the organization page if the course page
+        can not be found.
+        """
+        OrganizationFactory(code="sorbonne", page_title="Sorbonne", should_publish=True)
+
+        response = self.client.get("/courses/course-v1:sorbonne+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/sorbonne/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
+    def test_views_redirect_edx_courses_fallback_search_page(self):
+        """
+        OpenEdX course urls are redirected to the search page if neither the course page
+        nor the organization page can be found.
+        """
+        PageFactory(
+            reverse_id="search",
+            template="search/search.html",
+            title__title="Recherche",
+            title__language="fr",
+            should_publish=True,
+        )
+
+        response = self.client.get("/courses/course-v1:sorbonne+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/recherche/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
+    def test_views_redirect_edx_courses_no_fallback(self):
+        """
+        OpenEdX course urls are not redirected if the french version of the page is not
+        published (english is not yet activated on the public site).
+        """
+        course = CourseFactory(code="abc", page_title="Mon titre", should_publish=True)
+        TitleFactory(page=course.extended_object, language="en", title="My title")
+        course.extended_object.publish("en")
+        course.extended_object.unpublish("fr")
+
+        response = self.client.get("/courses/course-v1:org+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/courses/course-v1:org+abc+001/about/",
+            status_code=302,
+            target_status_code=404,
+            fetch_redirect_response=True,
+        )

--- a/sites/funmooc/src/backend/base/urls.py
+++ b/sites/funmooc/src/backend/base/urls.py
@@ -1,0 +1,16 @@
+"""
+API routes exposed by our base app.
+"""
+from django.urls import re_path
+
+from .views import redirect_edx_courses
+
+COURSE_KEY_PATTERN = r"course-v1:(?P<organization>.+)\+(?P<course>.+)\+(?P<session>.+)"
+
+urlpatterns = [
+    re_path(
+        r"courses/{}/about/?$".format(COURSE_KEY_PATTERN),
+        redirect_edx_courses,
+        name="redirect_edx_courses",
+    )
+]

--- a/sites/funmooc/src/backend/base/views.py
+++ b/sites/funmooc/src/backend/base/views.py
@@ -1,0 +1,40 @@
+"""Views for the fun-mooc site."""
+from django.db.models import Q
+from django.http import HttpResponsePermanentRedirect
+
+from cms.api import Page
+from cms.constants import PUBLISHER_STATE_PENDING
+from richie.apps.core.views.error import error_view_handler
+
+
+def redirect_edx_courses(request, organization, course, session):
+    """
+    The richie site is hosted on the same domain as OpenEdX before.
+    Redirect OpenEdX course urls to the corresponding Richie course urls.
+    """
+
+    def get_redirect_url(**kwargs):
+        """Look for a published page matching the kwargs query filters."""
+        try:
+            page = Page.objects.get(
+                ~Q(title_set__publisher_state=PUBLISHER_STATE_PENDING),
+                publisher_is_draft=False,
+                title_set__language=request.LANGUAGE_CODE,
+                title_set__published=True,
+                **kwargs
+            )
+        except Page.DoesNotExist:
+            return
+
+        return page.get_absolute_url(request.LANGUAGE_CODE)
+
+    url = (
+        get_redirect_url(course__code__iexact=course)
+        or get_redirect_url(organization__code__iexact=organization)
+        or get_redirect_url(reverse_id="search")
+    )
+
+    if url is None:
+        return error_view_handler(request, "Page not found", 404)
+
+    return HttpResponsePermanentRedirect(url)

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -665,6 +665,7 @@ class Development(Base):
 
 class Test(Base):
     """Test environment settings"""
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 
 class ContinuousIntegration(Test):

--- a/sites/funmooc/src/backend/funmooc/urls.py
+++ b/sites/funmooc/src/backend/funmooc/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
         r"api/{}/".format(API_PREFIX),
         include([*courses_urlpatterns, *search_urlpatterns]),
     ),
+    path(r"", include("base.urls")),
     path(r"", include("filer.server.urls")),
 ]
 


### PR DESCRIPTION
## Purpose

We don't want to lose all the traffic currently directed to course syllabus on OpenEdX. 

## Proposal
    
Add a view that catches these urls and tries to redirect them to the corresponding course, the corresponding university or as a last resort to the search page.
