### PR TITLE
🚸(all) prevent a pagetree node to be unfoldable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir /install && \
     # djangocms-admin-style should be removed when 2.0.3 will be released
     pip install --prefix=/install \ 
     git+https://github.com/jbpenrath/djangocms-admin-style@fun#egg=djangocms-admin-style \
-    git+https://github.com/jbpenrath/django-cms@fun-3.8.x#egg=django-cms
+    git+https://github.com/jbpenrath/django-cms@fun-3.8.xr1#egg=django-cms
 
 # ---- Core application image ----
 FROM base as core

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Set `CMS_PAGETREE_DESCENDANTS_LIMIT` setting to control pagetree search node
+  foldability according to its child node count
+
 ## [0.10.0] - 2021-01-14
 
 ### Changed

--- a/sites/cnfpt/src/backend/cnfpt/settings.py
+++ b/sites/cnfpt/src/backend/cnfpt/settings.py
@@ -546,6 +546,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
+    # Admin
+    # - Django CMS
+    # Maximum children nodes to allow a parent to be unfoldable
+    # in the page tree admin view
+    CMS_PAGETREE_DESCENDANTS_LIMIT = 80
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Set `CMS_PAGETREE_DESCENDANTS_LIMIT` setting to control pagetree search node
+  foldability according to its child node count
+
 ## [1.4.0] - 2021-01-14
 
 ### Changed

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -512,6 +512,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
+    # Admin
+    # - Django CMS
+    # Maximum children nodes to allow a parent to be unfoldable
+    # in the page tree admin view
+    CMS_PAGETREE_DESCENDANTS_LIMIT = 80
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Set `CMS_PAGETREE_DESCENDANTS_LIMIT` setting to control pagetree search node
+  foldability according to its child node count
+
 ## [1.3.0] - 2021-01-14
 
 ### Changed

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -508,6 +508,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
+    # Admin
+    # - Django CMS
+    # Maximum children nodes to allow a parent to be unfoldable
+    # in the page tree admin view
+    CMS_PAGETREE_DESCENDANTS_LIMIT = 80
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Set `CMS_PAGETREE_DESCENDANTS_LIMIT` setting to control pagetree search node
+  foldability according to its child node count
+
 ## [1.3.0] - 2021-01-14
 
 ### Changed

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -496,6 +496,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
+    # Admin
+    # - Django CMS
+    # Maximum children nodes to allow a parent to be unfoldable
+    # in the page tree admin view
+    CMS_PAGETREE_DESCENDANTS_LIMIT = 80
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Set `CMS_PAGETREE_DESCENDANTS_LIMIT` setting to control pagetree search node
+  foldability according to its child node count
+  
 ## [0.19.0] - 2021-01-14
 
 ### Changed

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -600,6 +600,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
+    # Admin
+    # - Django CMS
+    # Maximum children nodes to allow a parent to be unfoldable
+    # in the page tree admin view
+    CMS_PAGETREE_DESCENDANTS_LIMIT = 80
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):


### PR DESCRIPTION
Upgrade our Django CMS fork to tag [fun-3.8.xr1](https://github.com/jbpenrath/django-cms/tree/fun-3.8.xr1) to add control of page tree node
foldability. Set `CMS_PAGETREE_DESCENDANTS_LIMIT` to 30. If a pagetree node has
more than 30 children, user will not be able to unfold it.


![Preview](https://user-images.githubusercontent.com/9265241/106663114-904d6d00-65a3-11eb-8e7f-d547689f61a7.png)
