### PR TITLE
🚸(global) use custom views to handle errors

### DIFF
--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Use custom views to handle errors (400, 403, 404, 500)
+
 ## [1.0.0] - 2021-02-05
 
 ### Changed

--- a/sites/cnfpt/src/backend/cnfpt/urls.py
+++ b/sites/cnfpt/src/backend/cnfpt/urls.py
@@ -58,3 +58,8 @@ if settings.DEBUG:
         + staticfiles_urlpatterns()
         + urlpatterns
     )
+
+handler400 = "richie.apps.core.views.error.error_400_view_handler"
+handler403 = "richie.apps.core.views.error.error_403_view_handler"
+handler404 = "richie.apps.core.views.error.error_404_view_handler"
+handler500 = "richie.apps.core.views.error.error_500_view_handler"

--- a/sites/cnfpt/src/frontend/scss/_main.scss
+++ b/sites/cnfpt/src/frontend/scss/_main.scss
@@ -89,6 +89,7 @@
 @import './components/footer';
 @import 'richie-education/scss/components/styleguide';
 @import 'richie-education/scss/components/content';
+@import 'richie-education/scss/components/error';
 @import 'richie-education/scss/components/templates/search/search';
 @import 'richie-education/scss/components/templates/richie/single-column';
 @import './components/templates/courses/cms/homepage';

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Use custom views to handle errors (400, 403, 404, 500)
+
 ## [1.5.0] - 2021-02-05
 
 ### Changed

--- a/sites/demo/src/backend/demo/urls.py
+++ b/sites/demo/src/backend/demo/urls.py
@@ -58,3 +58,8 @@ if settings.DEBUG:
         + staticfiles_urlpatterns()
         + urlpatterns
     )
+
+handler400 = "richie.apps.core.views.error.error_400_view_handler"
+handler403 = "richie.apps.core.views.error.error_403_view_handler"
+handler404 = "richie.apps.core.views.error.error_404_view_handler"
+handler500 = "richie.apps.core.views.error.error_500_view_handler"

--- a/sites/demo/src/frontend/scss/_main.scss
+++ b/sites/demo/src/frontend/scss/_main.scss
@@ -89,6 +89,7 @@
 @import 'richie-education/scss/components/footer';
 @import 'richie-education/scss/components/styleguide';
 @import 'richie-education/scss/components/content';
+@import 'richie-education/scss/components/error';
 @import 'richie-education/scss/components/templates/search/search';
 @import 'richie-education/scss/components/templates/richie/single-column';
 @import 'richie-education/scss/components/templates/courses/cms/homepage';

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Use custom views to handle errors (400, 403, 404, 500)
+
+
 ## [1.4.0] - 2021-02-05
 
 ### Changed

--- a/sites/funcampus/src/backend/funcampus/urls.py
+++ b/sites/funcampus/src/backend/funcampus/urls.py
@@ -58,3 +58,8 @@ if settings.DEBUG:
         + staticfiles_urlpatterns()
         + urlpatterns
     )
+
+handler400 = "richie.apps.core.views.error.error_400_view_handler"
+handler403 = "richie.apps.core.views.error.error_403_view_handler"
+handler404 = "richie.apps.core.views.error.error_404_view_handler"
+handler500 = "richie.apps.core.views.error.error_500_view_handler"

--- a/sites/funcampus/src/frontend/scss/_main.scss
+++ b/sites/funcampus/src/frontend/scss/_main.scss
@@ -89,6 +89,7 @@
 @import 'richie-education/scss/components/footer';
 @import 'richie-education/scss/components/styleguide';
 @import 'richie-education/scss/components/content';
+@import 'richie-education/scss/components/error';
 @import 'richie-education/scss/components/templates/search/search';
 @import 'richie-education/scss/components/templates/richie/single-column';
 @import './components/templates/courses/cms/homepage';

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Use custom views to handle errors (400, 403, 404, 500)
+
+
 ## [1.4.0] - 2021-02-05
 
 ### Changed

--- a/sites/funcorporate/src/backend/funcorporate/urls.py
+++ b/sites/funcorporate/src/backend/funcorporate/urls.py
@@ -58,3 +58,8 @@ if settings.DEBUG:
         + staticfiles_urlpatterns()
         + urlpatterns
     )
+
+handler400 = "richie.apps.core.views.error.error_400_view_handler"
+handler403 = "richie.apps.core.views.error.error_403_view_handler"
+handler404 = "richie.apps.core.views.error.error_404_view_handler"
+handler500 = "richie.apps.core.views.error.error_500_view_handler"

--- a/sites/funcorporate/src/frontend/scss/_main.scss
+++ b/sites/funcorporate/src/frontend/scss/_main.scss
@@ -89,6 +89,7 @@
 @import 'richie-education/scss/components/footer';
 @import 'richie-education/scss/components/styleguide';
 @import 'richie-education/scss/components/content';
+@import 'richie-education/scss/components/error';
 @import 'richie-education/scss/components/templates/search/search';
 @import 'richie-education/scss/components/templates/richie/single-column';
 @import 'richie-education/scss/components/templates/courses/cms/homepage';

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Use custom views to handle errors (400, 403, 404, 500)
+
+
 ## [1.0.0] - 2021-02-05
 
 ### Added

--- a/sites/funmooc/src/backend/funmooc/urls.py
+++ b/sites/funmooc/src/backend/funmooc/urls.py
@@ -59,3 +59,8 @@ if settings.DEBUG:
         + staticfiles_urlpatterns()
         + urlpatterns
     )
+
+handler400 = "richie.apps.core.views.error.error_400_view_handler"
+handler403 = "richie.apps.core.views.error.error_403_view_handler"
+handler404 = "richie.apps.core.views.error.error_404_view_handler"
+handler500 = "richie.apps.core.views.error.error_500_view_handler"

--- a/sites/funmooc/src/frontend/scss/_main.scss
+++ b/sites/funmooc/src/frontend/scss/_main.scss
@@ -89,6 +89,7 @@
 @import 'richie-education/scss/components/footer';
 @import 'richie-education/scss/components/styleguide';
 @import 'richie-education/scss/components/content';
+@import 'richie-education/scss/components/error';
 @import 'richie-education/scss/components/templates/search/search';
 @import 'richie-education/scss/components/templates/richie/single-column';
 @import './components/templates/courses/cms/homepage';


### PR DESCRIPTION
## Purpose

Default error pages are ugly. In Richie we created custom error templates in line with our styleguides.

## Proposal
- [x] Use Richie's error templates