### PR TITLE
📈(funmooc) enable xiti tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,252 +334,32 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-cnfpt
-                site: cnfpt
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-changelog--cnfpt
-                site: cnfpt
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-front-production-cnfpt
-                site: cnfpt
-            - lint-front:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-front-cnfpt
-                requires:
-                    - build-front-production-cnfpt
-                site: cnfpt
-            - build-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: build-back-cnfpt
-                site: cnfpt
-            - lint-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - test-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: test-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - hub:
-                filters:
-                    tags:
-                        only: /^cnfpt-.*/
-                image_name: cnfpt
-                name: hub-cnfpt
-                requires:
-                    - lint-front-cnfpt
-                    - lint-back-cnfpt
-                site: cnfpt
+                        only: /.*/
+                name: no-change-cnfpt
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Upgrade richie to 2.3.0
 
+### Added
+
+- Enable Xiti traffic analytics
+
 ## [1.1.0] - 2021-03-05
 
 ### Added

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Enable Xiti traffic analytics
+- Add Cookies consent using [tarteaucitron](https://tarteaucitron.io)
 
 ## [1.1.0] - 2021-03-05
 

--- a/sites/funmooc/src/backend/base/context_processors.py
+++ b/sites/funmooc/src/backend/base/context_processors.py
@@ -1,0 +1,58 @@
+"""
+Template context_processors
+"""
+import json
+
+from django.conf import settings
+from django.db.models import Q
+from django.utils.translation import get_language_from_request
+
+from richie.apps.courses.models import Organization
+
+
+def site_metas(request):
+    """
+    Context processor to add all information required by frontend scripts.
+    """
+
+    page = request.current_page or None
+    language = get_language_from_request(request, check_path=True)
+
+    def get_organizations():
+        """
+        Return organization attached to the page and
+        organizations linked to the current page via an organization plugin in any of the
+        placeholders on the page
+        """
+        return list(
+            Organization.objects.filter(
+                Q(
+                    extended_object__organization_plugins__cmsplugin_ptr__language=language,
+                    extended_object__organization_plugins__cmsplugin_ptr__placeholder__page=page,
+                )
+                | Q(
+                    extended_object__exact=page,
+                ),
+                extended_object__title_set__published=True,
+            )
+            .distinct()
+            .values_list("code", flat=True)
+        )
+
+    context = {
+        "MARKETING_CONTEXT": json.dumps(
+            {
+                "xiti": {
+                    "level2": str(page.node.get_root().pk),
+                    "organizations": get_organizations() if not page.is_home else [],
+                    "site_id": settings.MARKETING_SITE_ID,
+                }
+                if getattr(settings, "MARKETING_SITE_ID", None)
+                and page is not None
+                and page.publisher_is_draft is False
+                else {},
+            }
+        )
+    }
+
+    return context

--- a/sites/funmooc/src/backend/base/static/funmooc/js/tarteaucitron.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/tarteaucitron.js
@@ -1,0 +1,48 @@
+(function () {
+  // Enforce to use document language
+  tarteaucitronForceLanguage = (document.documentElement.lang || '-').split('-')[0].toLowerCase();
+  var privacyUrl = window.__funmooc_context__.privacy.tarteaucitron.privacyUrl || '';
+
+  tarteaucitron.init({
+    "AcceptAllCta": true, /* Show the accept all button when highPrivacy on */
+    "adblocker": false, /* Show a Warning if an adblocker is detected */
+    "bodyPosition": "top", /* Position in the html */
+    "closePopup": true, /* Show a close X on the banner */
+    // "cookieDomain": ".my-multisite-domaine.fr", /* Shared cookie for multisite */
+    "cookieName": "tarteaucitron", /* Cookie name */
+    "cookieslist": false, /* Show the cookie list */
+    "DenyAllCta": true, /* Show the deny all button */
+    "handleBrowserDNTRequest": true, /* If Do Not Track == 1, disallow all */
+    "hashtag": "#tarteaucitron", /* Open the panel with this hashtag */
+    "highPrivacy": true, /* Disable auto consent */
+    "iconPosition": "BottomRight", /* BottomRight, BottomLeft, TopRight and TopLeft */
+    "mandatory": true, /* Show a message about mandatory cookies */
+    "moreInfoLink": true, /* Show more info link */
+    "orientation": "bottom", /* Banner position (top - bottom) */
+    "privacyUrl": privacyUrl, /* Privacy policy url */
+    "readmoreLink": "", /* Change the default readmore link */
+    "removeCredit": true, /* Remove credit link */
+    "showAlertSmall": false, /* Show the small banner on bottom right */
+    "showIcon": false, /* Show cookie icon to manage cookies */
+    "useExternalCss": false, /* If false, the tarteaucitron.css file will be loaded */
+    "useExternalJs": false, /* If false, the tarteaucitron.js file will be loaded */
+  });
+
+  tarteaucitron.job = tarteaucitron.job || [];
+
+  // If xiti is used, add this service
+  if (!!window.__funmooc_context__.marketing.xiti.site_id) {
+    tarteaucitron.services.xiti = {
+      key: 'xiti',
+      type: 'analytic',
+      name: 'Xiti',
+      uri: 'https://www.atinternet.com/societe/rgpd-et-vie-privee/',
+      needConsent: true,
+      safeanalytic: true,
+      cookies: ['atid', 'idrxvr', 'atuserid', 'atidx', 'atidvisitor'],
+    }
+
+    tarteaucitron.job.push('xiti');
+  }
+})();
+

--- a/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
@@ -1,0 +1,152 @@
+(function () {
+  function SmartTag(metadata) {
+    /**
+     * 
+     * SmartTag
+     * An object to install, initialize then use Xiti SmartTag.
+     * 
+     * @param metadata
+     *  site_id Xiti id to identify the site on Analytics Suite
+     *  level2 the level2 of the page - an id used by Xiti to group records by root pages
+     *  organizations - list of all organizations included on the page
+     * 
+     */
+    this.data = null;
+    this.level2 = metadata.level2;
+    this.organizations = metadata.organizations;
+    this.siteId = metadata.site_id;
+    this.tag = null;
+
+    /* Populate the data object sent to Xiti on dispatch
+      It includes level2, name and chapters
+
+      To get name and chapters we split the url pathname "/"
+      name is the first element of this destructuring
+      chapters are the remaining elements
+    */
+    this.populateData = function () {
+      var self = this;
+      var chapters = location.pathname
+        .split('/')
+        .filter(function (slug) { return slug.length > 0 })
+        .slice(1) // Remove lang
+
+      var name = chapters.shift();
+
+      this.data = {
+        level2: this.level2,
+        name: name || '/',
+      }
+
+      chapters.forEach(function (chapter, index) {
+        self.data["chapter" + (index + 1)] = '[' + chapter + ']';
+      });
+    };
+
+    /* Dispatch data on page load
+
+      Set customVars, customObject and internalSearch if it is relevant
+      then dispatch a record.
+    */
+    this.dispatch = function () {
+      // Detail language
+      var lang = (document.documentElement.lang || '-').split('-')[0].toLowerCase();
+      if (lang) {
+        this.tag.customVars.set({ site: { 1: '[' + lang + ']' } });
+      }
+
+      // Detail organizations related to the page
+      if (this.organizations.length > 0) {
+        var serializedOrganizations = '[' + this.organizations.map(function (organization) {
+          return '"' + organization + '"';
+        }).toString() + ']';
+        this.tag.setProp('a:s:organizations', serializedOrganizations, true);
+      }
+
+      // Detail search query if there is
+      var search_query = new URL(location.href).searchParams.get('query');
+      if (search_query) {
+        this.tag.internalSearch.set({
+          keyword: search_query,
+        });
+      }
+
+      // Dispatch data
+      this.tag.page.set(this.data)
+      this.tag.dispatch();
+    }
+
+
+    /* Instantiate the Xiti tag
+
+       Check if ATInternet exists then create a new tag.
+    */
+    this.createTag = function () {
+      if (ATInternet) {
+        this.tag = new ATInternet.Tracker.Tag({ site: this.siteId, secure: true });
+      }
+    }
+
+    /* Initialize SmartTag
+
+      Load Xiti scripts then dispatch a record and add click listeners on buttons
+    */
+    this.init = function () {
+      var self = this;
+      this.load(function () {
+        self.dispatch();
+        self.spyClickOnButtons();
+      })
+    }
+
+    /* Load Xiti scripts on the page
+
+      Dynamicaly load scripts required by Xiti only if needed
+    */
+    this.load = function (onload) {
+      var self = this;
+      var script = document.createElement('script');
+      script.type = "text/javascript";
+      script.async = true;
+      script.onload = function () {
+        self.createTag();
+        self.populateData();
+        onload && onload();
+      };
+      script.onerror = function (error) { throw error };
+      script.src = "https://tag.aticdn.net/" + this.siteId + "/smarttag.js"
+      document.body.append(script)
+    };
+
+    /* Add click event listeners on all buttons on the page
+
+      Send a record each time a visitor click on an action button on the page.
+    */
+    this.spyClickOnButtons = function () {
+      var self = this;
+
+      function spyClick(event) {
+        var $target = event.currentTarget;
+        var name = $target.innerText || $target.classList.value.replace(' ', '.');
+
+        var parameters = self.data;
+        parameters.elem = $target;
+        parameters.name = name;
+        parameters.type = 'action';
+
+        self.tag.click.send(parameters);
+      }
+
+      document.getElementsByTagName('button').forEach(function ($button) {
+        $button.addEventListener('click', spyClick, false);
+      });
+    }
+  }
+
+  // Ensure that Xiti is configured
+  if (!!window.__funmooc_context__.marketing.xiti.site_id) {
+    var smartTag = new SmartTag(__funmooc_context__.marketing.xiti);
+    smartTag.init();
+  }
+})();
+

--- a/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
@@ -143,8 +143,8 @@
     }
   }
 
-  // Ensure that Xiti is configured
-  if (!!window.__funmooc_context__.marketing.xiti.site_id) {
+  // Ensure that Xiti is configured and user allowed Xiti cookies
+  if (!!window.__funmooc_context__.marketing.xiti.site_id && tarteaucitron.cookie.read().includes('xiti=true')) {
     var smartTag = new SmartTag(__funmooc_context__.marketing.xiti);
     smartTag.init();
   }

--- a/sites/funmooc/src/backend/base/tests/test_context_processors.py
+++ b/sites/funmooc/src/backend/base/tests/test_context_processors.py
@@ -1,0 +1,135 @@
+"""Test funmooc context processors"""
+
+import re
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from richie.apps.core.factories import PageFactory, UserFactory
+from richie.apps.courses.factories import CourseFactory, OrganizationFactory
+
+
+class ContextProcessorsTestCase(TestCase):
+    """
+    Test suite for the context processors
+    """
+
+    @override_settings(MARKETING_SITE_ID="123456")
+    def test_context_processors_add_xiti_settings_if_exists(self):
+        """
+        Create a page and make sure it includes the marketing context as included
+        in `base.html`.
+        """
+        page = PageFactory(
+            should_publish=True,
+            template="richie/single_column.html",
+        )
+
+        response = self.client.get(page.get_public_url(), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"xiti":')
+        self.assertContains(response, f'"level2": "{page.node.get_root().pk}"')
+        self.assertContains(response, '"site_id": "123456"')
+
+    @override_settings(MARKETING_SITE_ID=None)
+    def test_context_processors_do_not_add_xiti_settings_if_marketing_site_id_is_not_defined(
+        self,
+    ):
+        """
+        If MARKETING_SIDE_ID setting is not defined,
+        frontend context should contains an empty xiti object
+        """
+        page = PageFactory(
+            should_publish=True,
+            template="richie/single_column.html",
+        )
+
+        response = self.client.get(page.get_public_url(), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"xiti": {}')
+
+    @override_settings(MARKETING_SITE_ID="123456")
+    def test_context_processors_do_not_add_xiti_settings_if_page_is_draft(
+        self,
+    ):
+        """
+        If the current page is a draft,
+        frontend context should contains an empty xiti object
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")  # nosec
+
+        page = PageFactory(
+            should_publish=False,
+            template="richie/single_column.html",
+        )
+
+        response = self.client.get(page.get_absolute_url(), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"xiti": {}')
+
+    @override_settings(MARKETING_SITE_ID="123456")
+    def test_context_processors_get_organizations_code(self):
+        """
+        If an organization is linked to the page or there are organization plugins on the page,
+        marketing context should contains the code of these organizations
+        """
+        organization = OrganizationFactory(should_publish=True)
+        course = CourseFactory(should_publish=True, fill_organizations=[organization])
+
+        response = self.client.get(course.extended_object.get_public_url(), follow=True)
+        pattern = r'"organizations": \["{code:s}"\]'.format(code=organization.code)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+
+    def test_context_processors_retrieve_privacy_page_url_if_exists(self):
+        """
+        If a privacy policy page exists,
+        tarteaucitron context should contains its url.
+        """
+        page = PageFactory(
+            should_publish=True,
+            template="richie/single_column.html",
+            title__language="fr",
+            languages="fr",
+        )
+
+        response = self.client.get(page.get_public_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"tarteaucitron":')
+        self.assertContains(response, '"privacyUrl": null')
+
+        privacy_page = PageFactory(
+            title__title="Privacy policy",
+            should_publish=True,
+            reverse_id="annex__privacy",
+            title__language="fr",
+            languages="fr",
+        )
+
+        response = self.client.get(page.get_public_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, f'"privacyUrl": "{privacy_page.get_public_url()}"'
+        )
+
+    def test_context_processors_queries_are_cached(self):
+        """
+        Once the page is cached, no db queries should be made again
+        """
+        organizations = OrganizationFactory.create_batch(
+            2, should_publish=True, page_languages=["fr"]
+        )
+        course = CourseFactory(
+            should_publish=True, fill_organizations=organizations, page_languages=["fr"]
+        )
+        page = course.extended_object
+
+        # Get the page a first time to cache it
+        self.client.get(page.get_public_url())
+
+        # Check that db queries are well cached
+        # The one remaining is related to django-cms
+        with self.assertNumQueries(1):
+            self.client.get(page.get_public_url())

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -292,6 +292,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                     "django.template.context_processors.static",
                     "cms.context_processors.cms_settings",
                     "richie.apps.core.context_processors.site_metas",
+                    "base.context_processors.site_metas",
                 ],
                 "loaders": [
                     "django.template.loaders.filesystem.Loader",
@@ -566,6 +567,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
             }
         },
     }
+
+    # Marketing
+    MARKETING_SITE_ID = values.Value(
+        None, environ_name="MARKETING_SITE_ID", environ_prefix=None
+    )
 
     # Demo
     RICHIE_DEMO_SITE_DOMAIN = "localhost:8080"

--- a/sites/funmooc/src/backend/templates/richie/base.html
+++ b/sites/funmooc/src/backend/templates/richie/base.html
@@ -20,3 +20,11 @@
 {% endblock topbar_contact %}
 
 {% block body_footer_title %}{% endblock body_footer_title %}
+{% block body_js %}
+    <script type="text/javascript">
+        window.__funmooc_context__ = {
+            marketing: JSON.parse('{{ MARKETING_CONTEXT|safe }}'),
+        }
+    </script>
+    <script type="text/javascript" src="{% static 'funmooc/js/xiti.js' %}"></script>
+{% endblock body_js %}

--- a/sites/funmooc/src/backend/templates/richie/base.html
+++ b/sites/funmooc/src/backend/templates/richie/base.html
@@ -23,8 +23,11 @@
 {% block body_js %}
     <script type="text/javascript">
         window.__funmooc_context__ = {
+            privacy: JSON.parse('{{ PRIVACY_CONTEXT|safe }}'),
             marketing: JSON.parse('{{ MARKETING_CONTEXT|safe }}'),
         }
     </script>
+    <script type="text/javascript" src="{% static 'richie/js/tarteaucitronjs/tarteaucitron.js' %}"></script>
+    <script type="text/javascript" src="{% static 'funmooc/js/tarteaucitron.js' %}"></script>
     <script type="text/javascript" src="{% static 'funmooc/js/xiti.js' %}"></script>
 {% endblock body_js %}

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -3,17 +3,19 @@
   "version": "1.1.0",
   "description": "Richie-powered CMS for fun-mooc.fr",
   "scripts": {
-    "build-ts": "webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js --env richie-dependent-build --env richie-settings=overrides.json",
+    "build-sass-production": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --style=compressed --load-path=node_modules",
+    "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",
     "build-ts-production": "webpack --mode=production --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js --env richie-dependent-build --env richie-settings=overrides.json",
+    "build-ts": "webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js --env richie-dependent-build --env richie-settings=overrides.json",
     "compile-translations": "node_modules/richie-education/i18n/compile-translations.js ./i18n/overrides/*.json ./i18n/locales/*.json",
     "extract-translations": "formatjs extract './**/*.ts*' --ignore ./node_modules --ignore './**/*.d.ts' --out-file './i18n/frontend.json' --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin",
+    "install-tarteaucitron": "mkdir -p ../backend/base/static/richie/js && cp -R node_modules/tarteaucitronjs ../backend/base/static/richie/js",
     "lint": "eslint -c node_modules/richie-education/.eslintrc.json 'js/**/*.ts?(x)' --rule 'import/no-extraneous-dependencies: [error, {packageDir: ['.', './node_modules/richie-education']}]' --no-error-on-unmatched-pattern",
-    "prettier": "prettier '**/*.+(css|scss)'",
+    "postinstall": "yarn install-tarteaucitron",
     "prettier-write": "prettier --write '**/*.+(css|scss)'",
-    "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",
-    "build-sass-production": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --style=compressed --load-path=node_modules",
-    "watch-ts": "yarn build-ts --watch",
-    "watch-sass": "nodemon -e scss -x 'yarn build-sass'"
+    "prettier": "prettier '**/*.+(css|scss)'",
+    "watch-sass": "nodemon -e scss -x 'yarn build-sass'",
+    "watch-ts": "yarn build-ts --watch"
   },
   "repository": {
     "type": "git",
@@ -33,7 +35,8 @@
   },
   "homepage": "https://github.com/openfun/richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "2.3.0"
+    "richie-education": "2.3.0",
+    "tarteaucitronjs": "1.8.5"
   },
   "devDependencies": {
     "@formatjs/cli": "2.13.5",

--- a/sites/funmooc/src/frontend/scss/_main.scss
+++ b/sites/funmooc/src/frontend/scss/_main.scss
@@ -106,5 +106,8 @@
 @import 'richie-education/scss/components/templates/courses/cms/program_list';
 @import 'richie-education/scss/components/templates/courses/cms/program_detail';
 
+// Libs
+@import './components/libs/tarteaucitron';
+
 // IE11 patchs
 @import 'richie-education/scss/trumps/ie11-fixes';

--- a/sites/funmooc/src/frontend/scss/components/libs/_tarteaucitron.scss
+++ b/sites/funmooc/src/frontend/scss/components/libs/_tarteaucitron.scss
@@ -1,0 +1,146 @@
+/*
+  Override tarteaucitron styles
+*/
+
+div#tarteaucitronRoot {
+  // fonts
+  * {
+    font-family: $r-font-family-hind !important;
+  }
+
+  .tarteaucitronH1,
+  .tarteaucitronH2 {
+    font-family: $r-font-family-montserrat !important;
+    font-weight: bold;
+  }
+
+  // Hide ugly icons
+  .tarteaucitronCross,
+  .tarteaucitronCheck {
+    display: none !important;
+  }
+
+  // All buttons
+  #tarteaucitronAlertBig button,
+  #tarteaucitron button {
+    @include button-small(
+      $font-color: r-theme-val(cookie-consent, light-color),
+      $font-family: $r-font-family-hind !important,
+      $font-size: 0.8rem !important,
+    );
+  }
+
+  #tarteaucitron .tarteaucitronTitle > button {
+    border-radius: 0;
+  } 
+
+  .tarteaucitronAllow {
+    background-color: r-theme-val(cookie-consent, cta-allow) !important;
+    border-radius: 100vw !important;
+  }
+
+  .tarteaucitronDeny {
+    background-color: r-theme-val(cookie-consent, cta-deny) !important;
+    border-radius: 100vw !important;
+  }
+
+  #tarteaucitronAlertBig button:not(.tarteaucitronAllow):not(.tarteaucitronDeny),
+  #tarteaucitronInfo button {
+    background: none;
+    text-decoration: underline;
+    margin-bottom: 0; 
+  }
+
+  // Banner
+  #tarteaucitronAlertBig {
+    background-color: r-theme-val(cookie-consent, base-background) !important;
+
+    #tarteaucitronDisclaimerAlert {
+      padding: 1.5rem 1rem;
+    }
+
+    #tarteaucitronCloseCross {
+      color: transparent;
+      top: 50%;
+      transform: translateY(-50%);
+      
+      &:after {
+        color: r-theme-val(cookie-consent, light-color);
+        content: '×';
+        font-size: 2rem;
+      }
+
+      @include media-breakpoint-down(md) {
+        display: none;
+      }
+    }
+  }
+
+  // Modal
+  #tarteaucitron {
+    div#tarteaucitronServices {
+      border-radius: 6px;
+      box-shadow: 0px 20px 30px #3333447F;
+      margin-top: 0 !important;
+      width: 100%;
+    }
+
+    // Reset scrollbar style
+    #tarteaucitronServices::-webkit-scrollbar {
+        width: inherit;
+    }
+
+    #tarteaucitronServices::-webkit-scrollbar-track {
+        box-shadow: inherit;
+    }
+
+    #tarteaucitronServices::-webkit-scrollbar-thumb {
+      background-color: inherit;
+      outline: inherit;
+    }
+
+    #tarteaucitronClosePanel {
+      @include button-base(
+        $padding-x: 0,
+        $padding-y: 0,
+        $focus-box-shadow: none,
+        $active-box-shadow: none
+      );
+      background: none;
+      border: none;
+      height: 0;
+      text-indent: 9999px;
+      top: 0;
+      transform: translateY(-50%);
+      width: 0;
+      word-break: keep-all;
+      z-index: 9999;
+      
+      &:after {
+        @include button-base();
+        color: r-theme-val(cookie-consent, light-color);
+        content: '×';
+        font-size: 1.5rem;
+        line-height: 1em;
+        padding: 1rem;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+    }
+
+    .tarteaucitronMainLine {
+      background-color: r-theme-val(cookie-consent, base-background) !important;
+      border: none !important;
+      
+      #tarteaucitronInfo, #tarteaucitronServices .tarteaucitronDetails, #tarteaucitronServices .tarteaucitronTitle button, #tarteaucitronAlertSmall #tarteaucitronCookiesListContainer #tarteaucitronCookiesList .tarteaucitronTitle {
+        background: none;
+        border: none;
+      }
+    }
+
+    .tarteaucitronBorder {
+      border: none;
+    }
+  }
+}

--- a/sites/funmooc/src/frontend/scss/settings/_colors.scss
+++ b/sites/funmooc/src/frontend/scss/settings/_colors.scss
@@ -234,6 +234,14 @@ $r-theme: (
     dark-gradient: $dark-gradient,
     white-mask-gradient: $white-mask-gradient,
   ),
+  cookie-consent:
+  (
+    base-background: r-color('darkish-blue'),
+    cta-allow: r-color('ocean-blue'),
+    cta-deny: r-color('indianred3'),
+    light-color: r-color('white'),
+    dark-color: r-color('dark'),
+  ),
   topbar: (
     base-background: null,
     over-background: null,

--- a/sites/funmooc/src/frontend/yarn.lock
+++ b/sites/funmooc/src/frontend/yarn.lock
@@ -7939,6 +7939,11 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
+tarteaucitronjs@1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/tarteaucitronjs/-/tarteaucitronjs-1.8.5.tgz#71303da7860550c799bed90c07710c1f670e6648"
+  integrity sha512-K0odmDKZuuBwzFcwAA60dsI5nbn0/ktVL4s+PRnhNmJ3QgFgr8ont8Xv43TklNSGkAz2jEhc6s6/BcfjxCWhxA==
+
 term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"


### PR DESCRIPTION
## Purpose
We would like to be able to get some analytics data from our visitors on FUN Mooc CMS.
We also need to compute a `level2` attribute from an immutable key to identify the root of the current page.
Furthermore, we also need to specify organization if there is one related to the current page. In this way, we will be able to give access to a customized (and restricted) analytics dashboard for each organizations.

## Proposal
- [x] Configure and initialize Xiti smart tag in a generic manner
- [x] Set level2 from the primary key of the page root node. 
- [x] Retrieve organizations included in any placeholders on the page
- [x] Require user's consent about cookie usage 

![Capture-d’écran-2021-03-09-à-18 06 05](https://user-images.githubusercontent.com/9265241/110509952-f8dbbc80-8102-11eb-9880-443ac0b47986.jpg)

<img width="1904" alt="Capture d’écran 2021-03-16 à 23 10 08" src="https://user-images.githubusercontent.com/9265241/111386697-eafedc00-86ac-11eb-8c39-b7419f7dc638.png">
<img width="1904" alt="Capture d’écran 2021-03-16 à 23 10 13" src="https://user-images.githubusercontent.com/9265241/111386714-f18d5380-86ac-11eb-8e84-e358be234b58.png">
