### PR TITLE
✨(funmooc) display first open course run in course detail top header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,12 @@ jobs:
                 keys:
                     - v1-back-dependencies-<< parameters.site >>-{{ .Revision }}
             - run:
+                command: sudo apt-get install -y gettext
+                name: Install gettext (required to compile messages)
+            - run:
+                command: python manage.py compilemessages
+                name: Compile translations
+            - run:
                 command: |
                     dockerize \
                       -wait tcp://localhost:5432 \

--- a/.circleci/src/jobs/@backend.yml
+++ b/.circleci/src/jobs/@backend.yml
@@ -94,6 +94,12 @@ test-back:
     - restore_cache:
         keys:
           - v1-back-dependencies-<< parameters.site >>-{{ .Revision }}
+    - run:
+        name: Install gettext (required to compile messages)
+        command: sudo apt-get install -y gettext
+    - run:
+        name: Compile translations
+        command: python manage.py compilemessages
     # Run back-end (Django) test suite
     #
     # Nota bene: to run the django test suite, we need to ensure that the

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ i18n-back: ## create/update .po files and compile .mo files used for i18n
 	@$(MANAGE) compilemessages
 .PHONY: i18n-back
 
-i18n-front: ## Compile translation files used for react-intl
+i18n-front: ## Extract and compile translation files used for react-intl
 	@$(YARN) extract-translations
 	@$(YARN) compile-translations
 .PHONY: i18n-front

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Display the first open course run in the header of the course detail page
 - Upgrade richie to 2.3.0
 
 ### Added

--- a/sites/funmooc/requirements/dev.txt
+++ b/sites/funmooc/requirements/dev.txt
@@ -10,3 +10,7 @@ pytest==6.2.1
 pytest-cov==2.10.1
 pytest-django==4.1.0
 raincoat==1.0.1
+
+# Testing html
+lxml==4.6.3
+cssselect==1.1.0

--- a/sites/funmooc/src/backend/base/tests/test_templates.py
+++ b/sites/funmooc/src/backend/base/tests/test_templates.py
@@ -1,0 +1,122 @@
+"""Test fun-mooc views."""
+import random
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import formats, timezone, translation
+
+import lxml.html  # nosec
+from lxml import etree  # nosec
+from richie.apps.courses.factories import CourseFactory, CourseRunFactory
+
+
+class TemplatesTestCase(TestCase):
+    """Test the funmooc template overrides."""
+
+    def test_templates_course_detail_no_open_course_run(self):
+        """For a course without course runs. It should be indicated in the side column."""
+        course = CourseFactory(should_publish=True)
+        page = course.extended_object
+
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        html = lxml.html.fromstring(response.content)
+
+        # Check syllabus intro
+        header = str(etree.tostring(html.cssselect(".subheader__intro")[0]))
+        self.assertNotIn("course-detail__run-descriptions", header)
+        self.assertNotIn("session", header)
+
+        # Check syllabus aside column
+        aside = str(etree.tostring(html.cssselect(".course-detail__aside")[0]))
+        self.assertNotIn("course-detail__run-descriptions", header)
+        self.assertNotIn("S&#226;&#128;&#153;inscrire maintenant", aside)
+        self.assertNotIn("Aucune autre session ouverte", aside)
+        self.assertIn("Aucune session ouverte", aside)
+
+    def test_templates_course_detail_one_open_course_run(self):
+        """
+        For a course with one open course run, the course run should be in the header
+        and the side column should display an indication that there is no other course run.
+        """
+        course = CourseFactory()
+        page = course.extended_object
+
+        # Create an open course run
+        now = timezone.now()
+        CourseRunFactory(
+            direct_course=course,
+            start=now + timedelta(hours=1),
+            enrollment_start=now - timedelta(hours=1),
+            enrollment_end=now + timedelta(hours=1),
+        )
+
+        self.assertTrue(page.publish("fr"))
+
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        html = lxml.html.fromstring(response.content)
+
+        # Check syllabus intro
+        header = str(etree.tostring(html.cssselect(".subheader__intro")[0]))
+        self.assertEqual(header.count("course-detail__run-descriptions"), 1)
+        self.assertIn("S&#226;&#128;&#153;inscrire maintenant", header)
+
+        # Check syllabus aside column
+        aside = str(etree.tostring(html.cssselect(".course-detail__aside")[0]))
+        self.assertNotIn("course-detail__run-descriptions", aside)
+        self.assertNotIn("S&#226;&#128;&#153;inscrire maintenant", aside)
+        self.assertIn("Aucune autre session ouverte", aside)
+
+    def test_templates_course_detail_two_open_course_runs(self):
+        """
+        For a course with two open course runs, the course run starting next should be in the
+        header and the other course run should be in the side column.
+        """
+        course = CourseFactory()
+        page = course.extended_object
+        url = page.get_absolute_url()
+
+        # Create 2 open course runs
+        now = timezone.now()
+        start1, start2 = random.sample(
+            [now + timedelta(days=1), now + timedelta(days=2)], 2
+        )
+        CourseRunFactory(
+            direct_course=course,
+            start=start1,
+            enrollment_start=now - timedelta(hours=1),
+            enrollment_end=now + timedelta(hours=1),
+        )
+        CourseRunFactory(
+            direct_course=course,
+            start=start2,
+            enrollment_start=now - timedelta(hours=1),
+            enrollment_end=now + timedelta(hours=1),
+        )
+
+        self.assertTrue(page.publish("fr"))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        html = lxml.html.fromstring(response.content)
+
+        # Check syllabus intro
+        header = str(etree.tostring(html.cssselect(".subheader__intro")[0]))
+        self.assertEqual(header.count("course-detail__runs--open"), 1)
+        self.assertIn("S&#226;&#128;&#153;inscrire maintenant", header)
+        date_string = formats.date_format(min(start1, start2))
+        with translation.override("fr"):
+            self.assertIn(f"Du {date_string}", header)
+
+        # Check syllabus aside column
+        aside = str(etree.tostring(html.cssselect(".course-detail__aside")[0]))
+        self.assertEqual(header.count("course-detail__runs--open"), 1)
+        self.assertIn("S&#226;&#128;&#153;inscrire maintenant", aside)
+        date_string = formats.date_format(max(start1, start2))
+        with translation.override("fr"):
+            self.assertIn(f"Du {date_string}", aside)

--- a/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-05 16:57+0100\n"
+"POT-Creation-Date: 2021-03-23 20:47+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,49 +45,66 @@ msgstr "Compte"
 msgid "{base_url:s}/account/settings"
 msgstr ""
 
-#: funmooc/settings.py:307
+#: funmooc/settings.py:308
 msgid "Teaser"
 msgstr "Accroche"
 
-#: funmooc/settings.py:386
+#: funmooc/settings.py:387
 msgid "New courses"
 msgstr "Nouveaux cours"
 
-#: funmooc/settings.py:390
+#: funmooc/settings.py:391
 msgid "First session"
 msgstr "Première session"
 
-#: funmooc/settings.py:401
+#: funmooc/settings.py:402
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: funmooc/settings.py:411
+#: funmooc/settings.py:412
 msgid "Languages"
 msgstr "Langues"
 
-#: funmooc/settings.py:426
+#: funmooc/settings.py:427
+msgid "Types"
+msgstr ""
+
+#: funmooc/settings.py:440
 msgid "Subjects"
 msgstr "Thématiques"
 
-#: funmooc/settings.py:439
+#: funmooc/settings.py:453
 msgid "Collections"
 msgstr "Collections"
 
-#: funmooc/settings.py:452
+#: funmooc/settings.py:466
 msgid "Organizations"
 msgstr "Établissements"
 
-#: funmooc/settings.py:465
+#: funmooc/settings.py:479
 msgid "Contributors"
 msgstr "Contributeurs"
 
-#: funmooc/settings.py:485 funmooc/settings.py:500
+#: funmooc/settings.py:499 funmooc/settings.py:514
 msgid "English"
 msgstr "Anglais"
 
-#: funmooc/settings.py:485 funmooc/settings.py:508
+#: funmooc/settings.py:499 funmooc/settings.py:522
 msgid "French"
 msgstr "Français"
+
+#: templates/courses/cms/course_detail.html:17
+msgctxt "course_detail__title"
+msgid "Other course runs"
+msgstr "Autres sessions"
+
+#: templates/courses/cms/course_detail.html:26
+msgid "No other open course runs"
+msgstr "Aucune autre session ouverte"
+
+#: templates/courses/cms/course_detail.html:30
+msgid "No open course runs"
+msgstr "Aucune session ouverte"
 
 #: templates/richie/base.html:18
 msgid "Help"

--- a/sites/funmooc/src/backend/templates/courses/cms/course_detail.html
+++ b/sites/funmooc/src/backend/templates/courses/cms/course_detail.html
@@ -1,3 +1,34 @@
 {% extends "courses/cms/course_detail.html" %}
+{% load cms_tags i18n %}
 
-{% block contact %}{% endblock contact %}
+{% block contact %}
+{% with runs_dict=course.course_runs_dict %}
+    <div class="course-detail__row course-detail__runs course-detail__runs--open">
+        {% for run in runs_dict.0|add:runs_dict.1|add:runs_dict.2|dictsort:"start"|slice:":1" %}
+            {% include "courses/cms/fragment_course_run.html" %}
+        {% endfor %}
+    </div>
+{% endwith %}
+{% endblock contact %}
+
+{% block runs_open %}
+<div class="course-detail__row course-detail__runs course-detail__runs--open">
+    <h2 class="course-detail__title">
+        {% blocktrans context "course_detail__title" %}Other course runs{% endblocktrans %}
+        {% render_model_add course "" "" "get_admin_url_to_add_run" %}
+    </h2>
+    {% with open_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|dictsort:"start" %}
+        {% for run in open_runs %}
+            {% if forloop.counter > 1 %}
+                {% include "courses/cms/fragment_course_run.html" %}
+            {% else %}
+                {% if forloop.last %}
+                    <div class="course-detail__empty">{% trans "No other open course runs" %}</div>
+                {% endif %}
+            {% endif %}
+        {% empty %}
+            <div class="course-detail__empty">{% trans "No open course runs" %}</div>
+        {% endfor %}
+    {% endwith %}
+</div>
+{% endblock runs_open %}

--- a/sites/funmooc/src/frontend/scss/_main.scss
+++ b/sites/funmooc/src/frontend/scss/_main.scss
@@ -98,7 +98,7 @@
 @import 'richie-education/scss/components/templates/courses/cms/organization_detail';
 @import 'richie-education/scss/components/templates/courses/cms/category_list';
 @import 'richie-education/scss/components/templates/courses/cms/category_detail';
-@import 'richie-education/scss/components/templates/courses/cms/course_detail';
+@import './components/templates/courses/cms/course_detail';
 @import 'richie-education/scss/components/templates/courses/cms/person_list';
 @import 'richie-education/scss/components/templates/courses/cms/person_detail';
 @import 'richie-education/scss/components/templates/courses/cms/blogpost_list';

--- a/sites/funmooc/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/sites/funmooc/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -1,0 +1,8 @@
+@import 'richie-education/scss/components/templates/courses/cms/course_detail';
+
+.course-detail {
+  &__row {
+    margin-top: 2rem;
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Purpose

Since we made the video teaser bigger on the course detail page header, the course run enrollment button was pushed below the fold. We want to feature it on top of the page.

## Proposal

Split open course runs in 2: 
- the first one is displayed in the page's header
- the remaining ones are displayed in the side column
- Appropriate notices are displayed when there is only one open course run or when there are no open course runs at all

## Screenshot

![image](https://user-images.githubusercontent.com/1427165/112185056-285cef80-8c00-11eb-9cb9-8f5791ed5fea.png)
