### PR TITLE
🐛(all) import missing stylesheet for LTI consumer plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,94 +340,259 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-cnfpt
-    demo:
-        jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-demo
-    funcampus:
-        jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-funcampus
-    funcorporate:
-        jobs:
-            - no-change:
-                filters:
-                    tags:
-                        only: /.*/
-                name: no-change-funcorporate
-    funmooc:
-        jobs:
             - check-changelog:
                 filters:
                     branches:
                         ignore: master
-                name: check-changelog-funmooc
-                site: funmooc
+                name: check-changelog-cnfpt
+                site: cnfpt
             - lint-changelog:
                 filters:
                     branches:
                         ignore: master
                     tags:
-                        only: /funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
+                        only: /cnfpt-.*/
+                name: lint-changelog--cnfpt
+                site: cnfpt
             - build-front-production:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
+                        only: /cnfpt-.*/
+                name: build-front-production-cnfpt
+                site: cnfpt
             - lint-front:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: lint-front-funmooc
+                        only: /cnfpt-.*/
+                name: lint-front-cnfpt
                 requires:
-                    - build-front-production-funmooc
-                site: funmooc
+                    - build-front-production-cnfpt
+                site: cnfpt
             - build-back:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
+                        only: /cnfpt-.*/
+                name: build-back-cnfpt
+                site: cnfpt
             - lint-back:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: lint-back-funmooc
+                        only: /cnfpt-.*/
+                name: lint-back-cnfpt
                 requires:
-                    - build-back-funmooc
-                site: funmooc
+                    - build-back-cnfpt
+                site: cnfpt
             - test-back:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: test-back-funmooc
+                        only: /cnfpt-.*/
+                name: test-back-cnfpt
                 requires:
-                    - build-back-funmooc
-                site: funmooc
+                    - build-back-cnfpt
+                site: cnfpt
             - hub:
                 filters:
                     tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
+                        only: /^cnfpt-.*/
+                image_name: cnfpt
+                name: hub-cnfpt
                 requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                    - lint-front-cnfpt
+                    - lint-back-cnfpt
+                site: cnfpt
+    demo:
+        jobs:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
+    funcampus:
+        jobs:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
+    funcorporate:
+        jobs:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
+    funmooc:
+        jobs:
+            - no-change:
+                filters:
+                    tags:
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing stylesheet for the LTI consumer plugin
+
 ## [1.2.0] - 2021-03-23
 
 ### Changed

--- a/sites/cnfpt/src/frontend/scss/_main.scss
+++ b/sites/cnfpt/src/frontend/scss/_main.scss
@@ -70,6 +70,7 @@
 @import 'richie-education/scss/objects/search-filter-value';
 @import 'richie-education/scss/objects/selector';
 @import 'richie-education/js/components/CourseRunEnrollment/styles';
+@import 'richie-education/js/components/LtiConsumer/styles';
 @import 'richie-education/js/components/SearchFilterGroup/styles';
 @import 'richie-education/js/components/SearchFilterGroupModal/styles';
 @import 'richie-education/js/components/SearchFiltersPane/styles';

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing stylesheet for the LTI consumer plugin
+
 ## [1.7.0] - 2021-03-23
 
 ### Changed

--- a/sites/demo/src/frontend/scss/_main.scss
+++ b/sites/demo/src/frontend/scss/_main.scss
@@ -70,6 +70,7 @@
 @import 'richie-education/scss/objects/search-filter-value';
 @import 'richie-education/scss/objects/selector';
 @import 'richie-education/js/components/CourseRunEnrollment/styles';
+@import 'richie-education/js/components/LtiConsumer/styles';
 @import 'richie-education/js/components/SearchFilterGroup/styles';
 @import 'richie-education/js/components/SearchFilterGroupModal/styles';
 @import 'richie-education/js/components/SearchFiltersPane/styles';

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing stylesheet for the LTI consumer plugin
+
 ## [1.6.0] - 2021-03-23
 
 ### Changed

--- a/sites/funcampus/src/frontend/scss/_main.scss
+++ b/sites/funcampus/src/frontend/scss/_main.scss
@@ -70,6 +70,7 @@
 @import 'richie-education/scss/objects/search-filter-value';
 @import 'richie-education/scss/objects/selector';
 @import 'richie-education/js/components/CourseRunEnrollment/styles';
+@import 'richie-education/js/components/LtiConsumer/styles';
 @import 'richie-education/js/components/SearchFilterGroup/styles';
 @import 'richie-education/js/components/SearchFilterGroupModal/styles';
 @import 'richie-education/js/components/SearchFiltersPane/styles';

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing stylesheet for the LTI consumer plugin
+
 ## [1.6.0] - 2021-03-23
 
 ### Changed

--- a/sites/funcorporate/src/frontend/scss/_main.scss
+++ b/sites/funcorporate/src/frontend/scss/_main.scss
@@ -70,6 +70,7 @@
 @import 'richie-education/scss/objects/search-filter-value';
 @import 'richie-education/scss/objects/selector';
 @import 'richie-education/js/components/CourseRunEnrollment/styles';
+@import 'richie-education/js/components/LtiConsumer/styles';
 @import 'richie-education/js/components/SearchFilterGroup/styles';
 @import 'richie-education/js/components/SearchFilterGroupModal/styles';
 @import 'richie-education/js/components/SearchFiltersPane/styles';


### PR DESCRIPTION
## Purpose

The stylesheet for the new LTI consumer plugin was missing resulting in a transparent background for example. 

## Proposal

This import was forgotten because it was not mentionned in upgrade instructions. Add it to the `_main.scss` file.

This is a follow-up of [this PR](https://github.com/openfun/richie-site-factory/pull/207) that we should have applied on all sites.
