### PR TITLE
🚸(search) rename "first session" filter to "new course"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,11 +368,66 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Rename filter "First session" to "New course" following user feedback
+
 ### Fixed
 
 - Add missing stylesheet for the LTI consumer plugin

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -388,7 +388,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 "min_doc_count": 0,
                 "name": "new",
                 "position": 0,
-                "values": {"new": _("First session")},
+                "values": {"new": _("New course")},
             },
         ),
         (

--- a/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -54,8 +54,8 @@ msgid "New courses"
 msgstr "Nouveaux cours"
 
 #: funmooc/settings.py:391
-msgid "First session"
-msgstr "Première session"
+msgid "New course"
+msgstr "Nouveau cours"
 
 #: funmooc/settings.py:402
 msgid "Availability"


### PR DESCRIPTION
## Purpose

Our support team requested to rename the "First session" filter to "New course" after some feedback proved that the wording was not clear.

## Proposal

Rename filter in settings and update translation files.