### PR TITLE
🔧(funcampus) update cloudfront distribution destination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,66 +368,11 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funmooc
-                site: funmooc
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-front-funmooc
-                requires:
-                    - build-front-production-funmooc
-                site: funmooc
-            - build-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - test-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: test-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - hub:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
-                requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/sites/funcampus/aws/config.tfvars
+++ b/sites/funcampus/aws/config.tfvars
@@ -2,6 +2,6 @@ site = "funcampus"
 
 app_domain = {
   production = "www.fun-campus.fr"
-  preprod = "preprod.funedu.oc.openfun.fr"
+  preprod = "preprod.funedu.apps.openfun.fr"
   staging = "staging.funedu.oc.openfun.fr"
 }


### PR DESCRIPTION
## Purpose

We are migrating funcampus preprod environment to a new cluster and its URL changed.

## Proposal

Update the cloudfront destination URL in terraform
