### PR TITLE
Feat/catch edx routes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,252 +340,32 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-cnfpt
-                site: cnfpt
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-changelog--cnfpt
-                site: cnfpt
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-front-production-cnfpt
-                site: cnfpt
-            - lint-front:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-front-cnfpt
-                requires:
-                    - build-front-production-cnfpt
-                site: cnfpt
-            - build-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: build-back-cnfpt
-                site: cnfpt
-            - lint-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - test-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: test-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - hub:
-                filters:
-                    tags:
-                        only: /^cnfpt-.*/
-                image_name: cnfpt
-                name: hub-cnfpt
-                requires:
-                    - lint-front-cnfpt
-                    - lint-back-cnfpt
-                site: cnfpt
+                        only: /.*/
+                name: no-change-cnfpt
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Redirect OpenEdX university urls to richie university pages
+
 ### Changed
 
 - Redirect old OpenEdX course urls to richie course pages

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Redirect old OpenEdX course urls to richie course pages
+
 ## [1.4.0] - 2021-04-07
 
 ### Changed

--- a/sites/funmooc/src/backend/base/tests/test_views.py
+++ b/sites/funmooc/src/backend/base/tests/test_views.py
@@ -26,6 +26,24 @@ class CoursesEdxRedirectViewsTestCase(TestCase):
             fetch_redirect_response=True,
         )
 
+    def test_views_redirect_edx_courses_success_with_old_course_uri(self):
+        """OpenEdX course urls are redirected to the corresponding page in richie."""
+        course = CourseFactory(
+            code="abc", page_title="Physique 101", should_publish=True
+        )
+        TitleFactory(page=course.extended_object, language="en", title="Physics 101")
+        course.extended_object.publish("en")
+
+        response = self.client.get("/courses/sorbonne/abc/001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/physique-101/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
     def test_views_redirect_edx_courses_fallback_organization(self):
         """
         OpenEdX course urls are redirected to the organization page if the course page

--- a/sites/funmooc/src/backend/base/tests/test_views.py
+++ b/sites/funmooc/src/backend/base/tests/test_views.py
@@ -5,8 +5,8 @@ from richie.apps.core.factories import PageFactory, TitleFactory
 from richie.apps.courses.factories import CourseFactory, OrganizationFactory
 
 
-class CoursesEdxRedirectViewsTestCase(TestCase):
-    """Test the "redirect_edx_courses" view."""
+class ResourcesEdxRedirectViewsTestCase(TestCase):
+    """Test the "redirect_edx_resources" view."""
 
     def test_views_redirect_edx_courses_success(self):
         """OpenEdX course urls are redirected to the corresponding page in richie."""
@@ -27,7 +27,7 @@ class CoursesEdxRedirectViewsTestCase(TestCase):
         )
 
     def test_views_redirect_edx_courses_success_with_old_course_uri(self):
-        """OpenEdX course urls are redirected to the corresponding page in richie."""
+        """Old OpenEdX course urls are redirected to the corresponding page in richie."""
         course = CourseFactory(
             code="abc", page_title="Physique 101", should_publish=True
         )
@@ -44,12 +44,36 @@ class CoursesEdxRedirectViewsTestCase(TestCase):
             fetch_redirect_response=True,
         )
 
+    def test_views_redirect_edx_organization_success(self):
+        """OpenEdX organization urls are redirected to the corresponding page in richie."""
+        organization = OrganizationFactory(
+            code="sorbonne",
+            page_title="Sorbonne",
+            should_publish=True,
+        )
+        TitleFactory(
+            page=organization.extended_object,
+            language="en",
+            title="Sorbonne",
+        )
+        organization.extended_object.publish("en")
+
+        response = self.client.get("/universities/sorbonne")
+
+        self.assertRedirects(
+            response,
+            "/fr/sorbonne/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
     def test_views_redirect_edx_courses_fallback_organization(self):
         """
         OpenEdX course urls are redirected to the organization page if the course page
         can not be found.
         """
-        OrganizationFactory(code="sorbonne", page_title="Sorbonne", should_publish=True)
+        OrganizationFactory(page_title="Sorbonne", code="sorbonne", should_publish=True)
 
         response = self.client.get("/courses/course-v1:sorbonne+abc+001/about/")
 
@@ -67,7 +91,7 @@ class CoursesEdxRedirectViewsTestCase(TestCase):
         nor the organization page can be found.
         """
         PageFactory(
-            reverse_id="search",
+            reverse_id="courses",
             template="search/search.html",
             title__title="Recherche",
             title__language="fr",

--- a/sites/funmooc/src/backend/base/urls.py
+++ b/sites/funmooc/src/backend/base/urls.py
@@ -3,7 +3,7 @@ API routes exposed by our base app.
 """
 from django.urls import re_path
 
-from .views import redirect_edx_courses
+from .views import redirect_edx_resources
 
 # Support both course OpenEdX routes
 #  http://open-fun.fr/courses/course-v1:acme+00001+session01/about
@@ -12,10 +12,18 @@ COURSE_KEY_PATTERN = (
     r"(course-v1:)?(?P<organization>.+)(\/|\+)(?P<course>.+)(\/|\+)(?P<session>.+)"
 )
 
+#  http://open-fun.fr/universities/acme/
+ORGANIZATION_KEY_PATTERN = r"(?P<organization>[^\/]*)"
+
 urlpatterns = [
     re_path(
         r"courses/{}/about/?$".format(COURSE_KEY_PATTERN),
-        redirect_edx_courses,
+        redirect_edx_resources,
+        name="redirect_edx_courses",
+    ),
+    re_path(
+        r"universities/{}/?$".format(ORGANIZATION_KEY_PATTERN),
+        redirect_edx_resources,
         name="redirect_edx_courses",
     ),
 ]

--- a/sites/funmooc/src/backend/base/urls.py
+++ b/sites/funmooc/src/backend/base/urls.py
@@ -5,12 +5,17 @@ from django.urls import re_path
 
 from .views import redirect_edx_courses
 
-COURSE_KEY_PATTERN = r"course-v1:(?P<organization>.+)\+(?P<course>.+)\+(?P<session>.+)"
+# Support both course OpenEdX routes
+#  http://open-fun.fr/courses/course-v1:acme+00001+session01/about
+#  http://open-fun.fr/courses/acme/00001/session01/about
+COURSE_KEY_PATTERN = (
+    r"(course-v1:)?(?P<organization>.+)(\/|\+)(?P<course>.+)(\/|\+)(?P<session>.+)"
+)
 
 urlpatterns = [
     re_path(
         r"courses/{}/about/?$".format(COURSE_KEY_PATTERN),
         redirect_edx_courses,
         name="redirect_edx_courses",
-    )
+    ),
 ]

--- a/sites/funmooc/src/backend/base/views.py
+++ b/sites/funmooc/src/backend/base/views.py
@@ -7,10 +7,11 @@ from cms.constants import PUBLISHER_STATE_PENDING
 from richie.apps.core.views.error import error_view_handler
 
 
-def redirect_edx_courses(request, organization, course, session):
+def redirect_edx_resources(request, organization, course=None, session=None):
     """
     The richie site is hosted on the same domain as OpenEdX before.
-    Redirect OpenEdX course urls to the corresponding Richie course urls.
+    Redirect OpenEdX course/organization urls
+    to the corresponding Richie course/organization urls.
     """
 
     def get_redirect_url(**kwargs):
@@ -29,9 +30,10 @@ def redirect_edx_courses(request, organization, course, session):
         return page.get_absolute_url(request.LANGUAGE_CODE)
 
     url = (
-        get_redirect_url(course__code__iexact=course)
+        course is not None
+        and get_redirect_url(course__code__iexact=course)
         or get_redirect_url(organization__code__iexact=organization)
-        or get_redirect_url(reverse_id="search")
+        or get_redirect_url(reverse_id="courses")
     )
 
     if url is None:


### PR DESCRIPTION
## Purpose
To not loose all the traffic currently directed to OpenEdX, we need to catch OpenEdX course and university routes then redirect them to the corresponding Richie page.

About course, we are already doing that but we did not catch the "old" OpenEdX route (`/<organization_id>/<course_id>/<session_id>`).
Concerning universities, the url to catch is `/universities/<organization_id>`

## Proposal
- [x] Catch old OpenEdX course urls to redirect visitor on the corresponding Richie course page
- [x] Catch OpenEdX university urls to redirect visitor on the corresponding Richie university page 