### PR TITLE
🔧(funmooc) update cloudfront production app_domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,66 +368,11 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funmooc
-                site: funmooc
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-front-funmooc
-                requires:
-                    - build-front-production-funmooc
-                site: funmooc
-            - build-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - test-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: test-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - hub:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
-                requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/sites/funmooc/aws/config.tfvars
+++ b/sites/funmooc/aws/config.tfvars
@@ -1,7 +1,7 @@
 site = "funmooc"
 
 app_domain = {
-  production = "new.fun-mooc.fr"
+  production = "www.fun-mooc.fr"
   preprod = "preprod.fun.oc.openfun.fr"
   staging = "staging.fun.oc.openfun.fr"
 }


### PR DESCRIPTION
## Purpose

In order to prepare the release of fun-mooc.fr, we have to update cloudfront
production cloudfront app_domain from new.fun-mooc.fr to www.fun-mooc.fr

## Proposal
- [x] Update `app_domain.production` in `config.tfvars`