### PR TITLE
🐛(funmooc) enable xiti by default

### DIFF
--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Send xiti hits unless visitor explicity refuses
+
 ## [1.5.0] - 2021-04-13
 
 ### Added

--- a/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
@@ -143,8 +143,8 @@
     }
   }
 
-  // Ensure that Xiti is configured and user allowed Xiti cookies
-  if (!!window.__funmooc_context__.marketing.xiti.site_id && tarteaucitron.cookie.read().includes('xiti=true')) {
+  // Ensure that Xiti is configured and user does not rejected Xiti cookies
+  if (!!window.__funmooc_context__.marketing.xiti.site_id && !tarteaucitron.cookie.read().includes('xiti=false')) {
     var smartTag = new SmartTag(__funmooc_context__.marketing.xiti);
     smartTag.init();
   }


### PR DESCRIPTION
## Purpose

In order to improve our marketing analytics, we can enable Xiti tracker unless visitor explicitly refuses to share its navigation information. Until now, we were asking visitor approval to send Xiti hits.

## Proposal

- [x] Send xiti hits unless user refused
