### PR TITLE
✅(funmooc) fix template test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,252 +340,32 @@ version: 2.1
 workflows:
     cnfpt:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-cnfpt
-                site: cnfpt
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-changelog--cnfpt
-                site: cnfpt
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-front-production-cnfpt
-                site: cnfpt
-            - lint-front:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-front-cnfpt
-                requires:
-                    - build-front-production-cnfpt
-                site: cnfpt
-            - build-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: build-back-cnfpt
-                site: cnfpt
-            - lint-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - test-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: test-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - hub:
-                filters:
-                    tags:
-                        only: /^cnfpt-.*/
-                image_name: cnfpt
-                name: hub-cnfpt
-                requires:
-                    - lint-front-cnfpt
-                    - lint-back-cnfpt
-                site: cnfpt
+                        only: /.*/
+                name: no-change-cnfpt
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:

--- a/sites/funmooc/src/backend/base/tests/test_templates.py
+++ b/sites/funmooc/src/backend/base/tests/test_templates.py
@@ -106,17 +106,29 @@ class TemplatesTestCase(TestCase):
         html = lxml.html.fromstring(response.content)
 
         # Check syllabus intro
-        header = str(etree.tostring(html.cssselect(".subheader__intro")[0]))
+        header = str(
+            etree.tostring(
+                html.cssselect(".subheader__intro")[0],
+                encoding="iso8859-1",
+                method="html",
+            ).decode("utf-8")
+        )
         self.assertEqual(header.count("course-detail__runs--open"), 1)
-        self.assertIn("S&#226;&#128;&#153;inscrire maintenant", header)
+        self.assertIn("S’inscrire maintenant", header)
         date_string = formats.date_format(min(start1, start2))
         with translation.override("fr"):
             self.assertIn(f"Du {date_string}", header)
 
         # Check syllabus aside column
-        aside = str(etree.tostring(html.cssselect(".course-detail__aside")[0]))
-        self.assertEqual(header.count("course-detail__runs--open"), 1)
-        self.assertIn("S&#226;&#128;&#153;inscrire maintenant", aside)
+        aside = str(
+            etree.tostring(
+                html.cssselect(".course-detail__aside")[0],
+                encoding="iso8859-1",
+                method="html",
+            ).decode("utf-8")
+        )
+        self.assertEqual(aside.count("course-detail__runs--open"), 1)
+        self.assertIn("S’inscrire maintenant", aside)
         date_string = formats.date_format(max(start1, start2))
         with translation.override("fr"):
             self.assertIn(f"Du {date_string}", aside)


### PR DESCRIPTION
A test failed due to a wrong html parsing. As contents in our tests are in french, we have to manage accentuated entities. To get a pretty string, when using etree.tostring we need first to encode this string in "ISO8859-1" (latin-1) then decode the result in "UTF-8"

This test failed just now, because the error ocurred when we check if the course run's start date is contained in the response.content. In french, august is the only month contaning accentuated characters (août) so this test failed only in August