### PR TITLE
[ademe] Fix LTI settings and domain for CloudFront proxying for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: /.*/
+                        ignore: master
                 name: check-changelog-ademe
                 site: ademe
             - lint-changelog:
@@ -402,39 +402,314 @@ workflows:
                 site: ademe
     cnfpt:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-cnfpt
+                site: cnfpt
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-changelog--cnfpt
+                site: cnfpt
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-cnfpt
+                        only: /cnfpt-.*/
+                name: build-front-production-cnfpt
+                site: cnfpt
+            - lint-front:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-front-cnfpt
+                requires:
+                    - build-front-production-cnfpt
+                site: cnfpt
+            - build-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: build-back-cnfpt
+                site: cnfpt
+            - lint-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: lint-back-cnfpt
+                requires:
+                    - build-back-cnfpt
+                site: cnfpt
+            - test-back:
+                filters:
+                    tags:
+                        only: /cnfpt-.*/
+                name: test-back-cnfpt
+                requires:
+                    - build-back-cnfpt
+                site: cnfpt
+            - hub:
+                filters:
+                    tags:
+                        only: /^cnfpt-.*/
+                image_name: cnfpt
+                name: hub-cnfpt
+                requires:
+                    - lint-front-cnfpt
+                    - lint-back-cnfpt
+                site: cnfpt
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcampus
+                        only: /funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
     funcorporate:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                        only: /funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: master
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:
@@ -442,7 +717,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: --ignore-changelog
+                ci_update_options: ""
                 filters:
                     branches:
                         ignore: master

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Configure Marsha video as LTI provider instead of "jisc.ac.uk" test platform
 - Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
 
+### Fixed
+
+- Fix staging and preprod domains for CloudFront proxying
+
 ## [0.1.0] - 2021-08-16
 
 ### Added

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Configure Marsha video as LTI provider instead of "jisc.ac.uk" test platform
 - Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
 
 ## [0.1.0] - 2021-08-16

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
 
 ## [0.1.0] - 2021-08-16
 

--- a/sites/ademe/aws/config.tfvars
+++ b/sites/ademe/aws/config.tfvars
@@ -2,6 +2,6 @@ site = "ademe"
 
 app_domain = {
   production = "new.mooc-batiment-durable.fr"
-  preprod = "preprod.ademe.apps.openfun.fr"
-  staging = "staging.ademe.apps.openfun.fr"
+  preprod = "richie.preprod-ademe.apps.openfun.fr"
+  staging = "richie.staging-ademe.apps.openfun.fr"
 }

--- a/sites/ademe/src/backend/ademe/settings.py
+++ b/sites/ademe/src/backend/ademe/settings.py
@@ -478,24 +478,26 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
 
     # LTI Content
     RICHIE_LTI_PROVIDERS = {
-        "lti_provider_demo": {
+        "marsha": {
             "oauth_consumer_key": values.Value(
-                "jisc.ac.uk",
+                "InsecureOauthConsumerKey",
                 environ_name="LTI_OAUTH_CONSUMER_KEY",
                 environ_prefix=None,
             ),
             "shared_secret": values.Value(
-                "secret",
+                "InsecureSharedSecret",
                 environ_name="LTI_SHARED_SECRET",
                 environ_prefix=None,
             ),
             "base_url": values.Value(
-                "https://lti.tools/saltire/tp",
+                "https://marsha\.education/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",  # noqa
                 environ_name="LTI_BASE_URL",
                 environ_prefix=None,
             ),
-            "display_name": "basic-lti-launch-request",
-            "inline_ratio": 0.75,
+            "display_name": "Marsha Video",
+            "is_base_url_regex": True,
+            "automatic_resizing": True,
+            "inline_ratio": 0.5625,
         }
     }
 

--- a/sites/ademe/src/backend/ademe/settings.py
+++ b/sites/ademe/src/backend/ademe/settings.py
@@ -481,17 +481,17 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "lti_provider_demo": {
             "oauth_consumer_key": values.Value(
                 "jisc.ac.uk",
-                environ_name="LTI_TEST_OAUTH_CONSUMER_KEY",
+                environ_name="LTI_OAUTH_CONSUMER_KEY",
                 environ_prefix=None,
             ),
             "shared_secret": values.Value(
                 "secret",
-                environ_name="LTI_TEST_SHARED_SECRET",
+                environ_name="LTI_SHARED_SECRET",
                 environ_prefix=None,
             ),
             "base_url": values.Value(
                 "https://lti.tools/saltire/tp",
-                environ_name="LTI_TEST_BASE_URL",
+                environ_name="LTI_BASE_URL",
                 environ_prefix=None,
             ),
             "display_name": "basic-lti-launch-request",

--- a/sites/cnfpt/CHANGELOG.md
+++ b/sites/cnfpt/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Set Django Check SEO up
 
+### Changed
+
+- Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
+
 ## [1.7.1] - 2021-06-08
 
 ### Fixed

--- a/sites/cnfpt/src/backend/cnfpt/settings.py
+++ b/sites/cnfpt/src/backend/cnfpt/settings.py
@@ -479,17 +479,17 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "marsha": {
             "oauth_consumer_key": values.Value(
                 "InsecureOauthConsumerKey",
-                environ_name="LTI_TEST_OAUTH_CONSUMER_KEY",
+                environ_name="LTI_OAUTH_CONSUMER_KEY",
                 environ_prefix=None,
             ),
             "shared_secret": values.Value(
                 "InsecureSharedSecret",
-                environ_name="LTI_TEST_SHARED_SECRET",
+                environ_name="LTI_SHARED_SECRET",
                 environ_prefix=None,
             ),
             "base_url": values.Value(
                 "https://marsha\.education/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",  # noqa
-                environ_name="LTI_TEST_BASE_URL",
+                environ_name="LTI_BASE_URL",
                 environ_prefix=None,
             ),
             "display_name": "Marsha Video",

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Set Django Check SEO up
 
+### Changed
+
+- Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
+
 ## [1.12.1] - 2021-06-08
 
 ### Fixed

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -490,17 +490,17 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "lti_provider_demo": {
             "oauth_consumer_key": values.Value(
                 "jisc.ac.uk",
-                environ_name="LTI_TEST_OAUTH_CONSUMER_KEY",
+                environ_name="LTI_OAUTH_CONSUMER_KEY",
                 environ_prefix=None,
             ),
             "shared_secret": values.Value(
                 "secret",
-                environ_name="LTI_TEST_SHARED_SECRET",
+                environ_name="LTI_SHARED_SECRET",
                 environ_prefix=None,
             ),
             "base_url": values.Value(
                 "https://lti.tools/saltire/tp",
-                environ_name="LTI_TEST_BASE_URL",
+                environ_name="LTI_BASE_URL",
                 environ_prefix=None,
             ),
             "display_name": "basic-lti-launch-request",

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Set Django Check SEO up
 
+### Changed
+
+- Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
+
 ## [1.11.0] - 2021-06-04
 
 ### Changed

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -467,17 +467,17 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "marsha": {
             "oauth_consumer_key": values.Value(
                 "InsecureOauthConsumerKey",
-                environ_name="LTI_TEST_OAUTH_CONSUMER_KEY",
+                environ_name="LTI_OAUTH_CONSUMER_KEY",
                 environ_prefix=None,
             ),
             "shared_secret": values.Value(
                 "InsecureSharedSecret",
-                environ_name="LTI_TEST_SHARED_SECRET",
+                environ_name="LTI_SHARED_SECRET",
                 environ_prefix=None,
             ),
             "base_url": values.Value(
                 "https://marsha\.education/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",  # noqa
-                environ_name="LTI_TEST_BASE_URL",
+                environ_name="LTI_BASE_URL",
                 environ_prefix=None,
             ),
             "display_name": "Marsha Video",

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Set Django Check SEO up
 
+### Changed
+
+- Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
+
 ## [1.11.0] - 2021-06-04
 
 ### Changed

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -451,17 +451,17 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "marsha": {
             "oauth_consumer_key": values.Value(
                 "InsecureOauthConsumerKey",
-                environ_name="LTI_TEST_OAUTH_CONSUMER_KEY",
+                environ_name="LTI_OAUTH_CONSUMER_KEY",
                 environ_prefix=None,
             ),
             "shared_secret": values.Value(
                 "InsecureSharedSecret",
-                environ_name="LTI_TEST_SHARED_SECRET",
+                environ_name="LTI_SHARED_SECRET",
                 environ_prefix=None,
             ),
             "base_url": values.Value(
                 "https://marsha\.education/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",  # noqa
-                environ_name="LTI_TEST_BASE_URL",
+                environ_name="LTI_BASE_URL",
                 environ_prefix=None,
             ),
             "display_name": "Marsha Video",

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Set Django Check SEO up
 
+### Changed
+
+- Rename `LTI_TEST_*` settings to `LTI_*` as "TEST" does not make sense here
+
 ## [1.8.1] - 2021-06-08
 
 ### Fixed

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -592,17 +592,17 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "marsha": {
             "oauth_consumer_key": values.Value(
                 "InsecureOauthConsumerKey",
-                environ_name="LTI_TEST_OAUTH_CONSUMER_KEY",
+                environ_name="LTI_OAUTH_CONSUMER_KEY",
                 environ_prefix=None,
             ),
             "shared_secret": values.Value(
                 "InsecureSharedSecret",
-                environ_name="LTI_TEST_SHARED_SECRET",
+                environ_name="LTI_SHARED_SECRET",
                 environ_prefix=None,
             ),
             "base_url": values.Value(
                 "https://marsha\.education/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",  # noqa
-                environ_name="LTI_TEST_BASE_URL",
+                environ_name="LTI_BASE_URL",
                 environ_prefix=None,
             ),
             "display_name": "Marsha Video",


### PR DESCRIPTION
### Purpose

Fix minor issues encountered when deploying the Ademe image to preprod and production environments.

### Proposal

- [x] fix staging and preprod domains for CloudFront proxying
- [x] set LTI providers to marsha video production

While doing these 2 fixes, I noticed that the LTI providers settings had "TEST" in their name which is a copy/pasta fail from Richie's sandbox, so I propose to correct it for all sites.
