### PR TITLE
📌(backend) remove use of forked djangocms-admin-style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,9 @@ RUN pip install --upgrade pip
 
 RUN mkdir /install && \
     pip install --prefix=/install -r requirements.txt \
-    # Use temporarily a forked version of django-cms and djangocms-admin-style
     # The django-cms fork includes drillable search feature,
-    # it should be removed when this feature will be officialy released.
-    # djangocms-admin-style should be removed when 2.0.3 will be released
-    pip install --prefix=/install \ 
-    git+https://github.com/jbpenrath/djangocms-admin-style@fun#egg=djangocms-admin-style \
+    # it should be removed when this feature will be officially released.
+    pip install --prefix=/install \
     git+https://github.com/jbpenrath/django-cms@fun-3.9.0#egg=django-cms
 
 # ---- Core application image ----


### PR DESCRIPTION
djangocms-admin-style 3.0.0 has been released and includes fixes we need. So we are now able to remove the use of our forked version of this package.