### PR TITLE
📈(funmooc) enable xiti course enrollment analytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,314 +341,39 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-ademe
-                site: ademe
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /ademe-.*/
-                name: lint-changelog--ademe
-                site: ademe
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /ademe-.*/
-                name: build-front-production-ademe
-                site: ademe
-            - lint-front:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: lint-front-ademe
-                requires:
-                    - build-front-production-ademe
-                site: ademe
-            - build-back:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: build-back-ademe
-                site: ademe
-            - lint-back:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: lint-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - test-back:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: test-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - hub:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                image_name: ademe
-                name: hub-ademe
-                requires:
-                    - lint-front-ademe
-                    - lint-back-ademe
-                site: ademe
+                        only: /.*/
+                name: no-change-ademe
     cnfpt:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-cnfpt
-                site: cnfpt
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-changelog--cnfpt
-                site: cnfpt
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-front-production-cnfpt
-                site: cnfpt
-            - lint-front:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-front-cnfpt
-                requires:
-                    - build-front-production-cnfpt
-                site: cnfpt
-            - build-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: build-back-cnfpt
-                site: cnfpt
-            - lint-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - test-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: test-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - hub:
-                filters:
-                    tags:
-                        only: /^cnfpt-.*/
-                image_name: cnfpt
-                name: hub-cnfpt
-                requires:
-                    - lint-front-cnfpt
-                    - lint-back-cnfpt
-                site: cnfpt
+                        only: /.*/
+                name: no-change-cnfpt
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: master
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,7 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Enable Xiti course enrollment analytics 
+
+### Changed
+
 - Upgrade richie to 2.13.0
+
 
 ## [1.13.0] - 2022-01-04
 

--- a/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
@@ -160,6 +160,7 @@
   }
 
   var context = window.__funmooc_context__.analytics;
+
   tarteaucitron.services.xitiFun = {
     key: 'xiti',
     type: 'analytic',
@@ -172,6 +173,8 @@
       function onLoad() {
         var smartTag = new SmartTag(context);
         smartTag.init();
+        // expose smartTag globally
+        window.smartTag = smartTag;
       }
       tarteaucitron.addScript(smarttag_url, '', onLoad);
     },

--- a/sites/funmooc/src/frontend/js/utils/api/web-analytics/index.ts
+++ b/sites/funmooc/src/frontend/js/utils/api/web-analytics/index.ts
@@ -1,0 +1,18 @@
+import type { Maybe } from 'richie-education/js/types/utils';
+import { WebAnalyticsAPI } from 'richie-education/js/types/WebAnalytics';
+import context from 'richie-education/js/utils/context';
+import { handle } from 'richie-education/js/utils/errors/handle';
+import FunXitiApi from '../../../../../../js/utils/api/web-analytics/xiti';
+
+const WebAnalyticsAPIHandler = (): Maybe<WebAnalyticsAPI> => {
+  try {
+    if (context?.web_analytics_provider === 'xiti') {
+      return new FunXitiApi();
+    }
+  } catch (error) {
+    handle(error);
+  }
+  return undefined;
+};
+
+export default WebAnalyticsAPIHandler;

--- a/sites/funmooc/src/frontend/js/utils/api/web-analytics/xiti.ts
+++ b/sites/funmooc/src/frontend/js/utils/api/web-analytics/xiti.ts
@@ -1,0 +1,35 @@
+/* eslint-disable class-methods-use-this */
+import { BaseWebAnalyticsApi } from 'richie-education/js/utils/api/web-analytics/base';
+
+/**
+ *
+ * Xiti Richie Web Analytics API Implementation
+ *
+ * This implementation is used when web analytics is configured as `xiti`.
+ * It will send events to the xiti.
+ *
+ */
+export default class FunXitiApi extends BaseWebAnalyticsApi {
+  tag: any;
+
+  constructor() {
+    super();
+
+    const smartTag = (window as any)?.smartTag;
+
+    // User has denied being tracked or an adblocker has blocked the tag initialization.
+    if (smartTag === undefined) {
+      return;
+    }
+
+    this.tag = smartTag.tag;
+  }
+
+  sendEvent(category: string, action: string, label: string): void {
+    this.tag?.setProp('s:resource_link', label, false);
+    this.tag?.click.send({
+      name: category,
+      type: 'action',
+    });
+  }
+}

--- a/sites/funmooc/src/frontend/overrides.json
+++ b/sites/funmooc/src/frontend/overrides.json
@@ -1,3 +1,5 @@
 {
-  "overrides": {}
+  "overrides": {
+    "^.*|(utils/api/web-analytics/index.ts)": "../../../../../../js/utils/api/web-analytics/index.ts"
+  }
 }


### PR DESCRIPTION
Since Richie 2.13.0, we are able to track when a user successfully
enrolls to a course. On FUN Mooc, we have to override the frontend part
to add Xiti support and respect user consent.

So from now, when an enrollment request to a course run succeeded, a `click.action` hit with name `courseEnroll` is sent to xiti. This hit contains a custom property `resource_link`. In this way, from Xiti analytic dashboard we are able to segment clicks by resource_link content (so segment by organization, course or course_run)

<img width="1378" alt="image" src="https://user-images.githubusercontent.com/9265241/156006913-f883db8f-babb-444a-aba5-98ee14c4f48e.png">
